### PR TITLE
Multithreading Support on predict_many_sk and predict_many_v2

### DIFF
--- a/history/management/commands/predict_many_sk.py
+++ b/history/management/commands/predict_many_sk.py
@@ -5,7 +5,7 @@ from history.tools import print_and_log
 from multiprocessing import Pool
 
 
-def do_classifier_test(name, ticker, data_set_inputs, granularity, min_back, timedelta_back):
+def do_prediction_test(name, ticker, data_set_inputs, granularity, min_back, timedelta_back):
     try:
         ct = ClassifierTest(name=name,
                             type='mock',
@@ -74,7 +74,7 @@ class Command(BaseCommand):
                         for timedelta_back_in_granularity_increments in \
                                 timedelta_back_in_granularity_increments_options:
                             for name in name_options:
-                                pool.apply_async(do_classifier_test, args=(
+                                pool.apply_async(do_prediction_test, args=(
                                     name,
                                     ticker,
                                     datasetinputs,

--- a/history/management/commands/predict_many_sk.py
+++ b/history/management/commands/predict_many_sk.py
@@ -2,11 +2,13 @@ from django.core.management.base import BaseCommand
 from history.models import ClassifierTest
 from django.conf import settings
 from history.tools import print_and_log
+from multiprocessing import Pool
 
 
 class Command(BaseCommand):
 
     help = 'tests various settings that could make the NN more accurate'
+    result_list = []
 
     def handle(self, *args, **options):
 
@@ -21,30 +23,59 @@ class Command(BaseCommand):
         datasetinput_options = [2]
         # TODO: enable more than just 1 type
 
-        timedelta_back_in_granularity_increments_options = [10, 30, 60, 100, 1000]  # sets how far apart (in granularity increments) the datasets are
+        # sets how far apart (in granularity increments) the datasets are
+        timedelta_back_in_granularity_increments_options = [10, 30, 60, 100, 1000]
 
         name_options = ["Nearest Neighbors", "Linear SVM", "RBF SVM", "Decision Tree",
                         "Random Forest", "AdaBoost", "Naive Bayes", "Linear Discriminant Analysis",
                         "Quadratic Discriminant Analysis"]
 
+        pool = Pool(settings.NUM_THREADS)
+
+        print("Starting SK Run")
         for ticker in ticker_options:
             for min_back in min_back_options:
                 for granularity in granularity_options:
                     for datasetinputs in datasetinput_options:
-                        for timedelta_back_in_granularity_increments in timedelta_back_in_granularity_increments_options:
+                        for timedelta_back_in_granularity_increments in \
+                                timedelta_back_in_granularity_increments_options:
                             for name in name_options:
-                                try:
-                                    ct = ClassifierTest(name=name,
-                                                        type='mock',
-                                                        symbol=ticker,
-                                                        datasetinputs=datasetinputs,
-                                                        granularity=granularity,
-                                                        minutes_back=min_back,
-                                                        timedelta_back_in_granularity_increments=timedelta_back_in_granularity_increments)
-                                    ct.get_classifier()
-                                    ct.save()
-                                    print_and_log("(ct) {} {} {} {} {} {} returned {}% corrrect ".format(name, ticker, datasetinputs, granularity, min_back, timedelta_back_in_granularity_increments, ct.percent_correct))
-                                    if ct.percent_correct > 60 or not settings.MAKE_TRADES:  # hack to only graph successful charts, until we figure out this warning http://bits.owocki.com/010Z1M3d170p/Image%202016-03-02%20at%208.30.17%20AM.png
-                                        ct.graph(ct.graph_url())
-                                except Exception as e:
-                                    print("exception:" + str(e))
+                                pool.apply_async(self._do_classifier_test, args=(
+                                    name,
+                                    ticker,
+                                    datasetinputs,
+                                    granularity,
+                                    min_back,
+                                    timedelta_back_in_granularity_increments
+                                ))
+        print("All SK Jobs queues")
+        pool.close()
+        pool.join()
+        print("SK Run Complete")
+        print(self.result_list)
+
+    def _do_classifier_test(self, name, ticker, data_set_inputs, granularity, min_back, timedelta_back):
+        try:
+            ct = ClassifierTest(name=name,
+                                type='mock',
+                                symbol=ticker,
+                                datasetinputs=data_set_inputs,
+                                granularity=granularity,
+                                minutes_back=min_back,
+                                timedelta_back_in_granularity_increments=timedelta_back)
+            ct.get_classifier()
+            ct.save()
+            return_data = "(ct) {} {} {} {} {} {} returned {}% correct ".format(name, ticker, data_set_inputs,
+                                                                                granularity,
+                                                                                min_back,
+                                                                                timedelta_back,
+                                                                                ct.percent_correct)
+
+            print_and_log(return_data)
+            # Hack to only graph successful charts, until we figure out this warning
+            # http://bits.owocki.com/010Z1M3d170p/Image%202016-03-02%20at%208.30.17%20AM.png
+            if ct.percent_correct > 60 or not settings.MAKE_TRADES:
+                ct.graph(ct.graph_url())
+            self.result_list.append(return_data)
+        except Exception as e:
+            print("exception:" + str(e))

--- a/history/management/commands/predict_many_sk.py
+++ b/history/management/commands/predict_many_sk.py
@@ -66,7 +66,7 @@ class Command(BaseCommand):
 
         pool = Pool(settings.NUM_THREADS)
 
-        print("Starting SK Run")
+        print("Starting SK run")
         for ticker in ticker_options:
             for min_back in min_back_options:
                 for granularity in granularity_options:
@@ -82,8 +82,9 @@ class Command(BaseCommand):
                                     min_back,
                                     timedelta_back_in_granularity_increments
                                 ), callback=self._log_results)
-        print("All SK Jobs queues")
+        print("All SK jobs queued")
         pool.close()
         pool.join()
-        print("SK Run Complete")
-        print(self.result_list)
+        print("SK run complete")
+        for result in self.result_list:
+            print(result)

--- a/history/management/commands/predict_many_sk.py
+++ b/history/management/commands/predict_many_sk.py
@@ -5,10 +5,44 @@ from history.tools import print_and_log
 from multiprocessing import Pool
 
 
+def do_classifier_test(name, ticker, data_set_inputs, granularity, min_back, timedelta_back):
+    try:
+        ct = ClassifierTest(name=name,
+                            type='mock',
+                            symbol=ticker,
+                            datasetinputs=data_set_inputs,
+                            granularity=granularity,
+                            minutes_back=min_back,
+                            timedelta_back_in_granularity_increments=timedelta_back)
+        ct.get_classifier()
+        ct.save()
+        return_data = "(ct) {} {} {} {} {} {} returned {}% correct ".format(name, ticker, data_set_inputs,
+                                                                            granularity,
+                                                                            min_back,
+                                                                            timedelta_back,
+                                                                            ct.percent_correct)
+
+        print_and_log(return_data)
+        # Hack to only graph successful charts, until we figure out this warning
+        # http://bits.owocki.com/010Z1M3d170p/Image%202016-03-02%20at%208.30.17%20AM.png
+        if ct.percent_correct > 60 or not settings.MAKE_TRADES:
+            ct.graph(ct.graph_url())
+        return return_data
+    except Exception as e:
+        return "Exception in {} {} {} {} {} {}: {}".format(name, ticker, data_set_inputs,
+                                                           granularity,
+                                                           min_back,
+                                                           timedelta_back,
+                                                           str(e))
+
+
 class Command(BaseCommand):
 
     help = 'tests various settings that could make the NN more accurate'
     result_list = []
+
+    def _log_results(self, result):
+        self.result_list.append(result)
 
     def handle(self, *args, **options):
 
@@ -40,42 +74,16 @@ class Command(BaseCommand):
                         for timedelta_back_in_granularity_increments in \
                                 timedelta_back_in_granularity_increments_options:
                             for name in name_options:
-                                pool.apply_async(self._do_classifier_test, args=(
+                                pool.apply_async(do_classifier_test, args=(
                                     name,
                                     ticker,
                                     datasetinputs,
                                     granularity,
                                     min_back,
                                     timedelta_back_in_granularity_increments
-                                ))
+                                ), callback=self._log_results)
         print("All SK Jobs queues")
         pool.close()
         pool.join()
         print("SK Run Complete")
         print(self.result_list)
-
-    def _do_classifier_test(self, name, ticker, data_set_inputs, granularity, min_back, timedelta_back):
-        try:
-            ct = ClassifierTest(name=name,
-                                type='mock',
-                                symbol=ticker,
-                                datasetinputs=data_set_inputs,
-                                granularity=granularity,
-                                minutes_back=min_back,
-                                timedelta_back_in_granularity_increments=timedelta_back)
-            ct.get_classifier()
-            ct.save()
-            return_data = "(ct) {} {} {} {} {} {} returned {}% correct ".format(name, ticker, data_set_inputs,
-                                                                                granularity,
-                                                                                min_back,
-                                                                                timedelta_back,
-                                                                                ct.percent_correct)
-
-            print_and_log(return_data)
-            # Hack to only graph successful charts, until we figure out this warning
-            # http://bits.owocki.com/010Z1M3d170p/Image%202016-03-02%20at%208.30.17%20AM.png
-            if ct.percent_correct > 60 or not settings.MAKE_TRADES:
-                ct.graph(ct.graph_url())
-            self.result_list.append(return_data)
-        except Exception as e:
-            print("exception:" + str(e))

--- a/history/management/commands/predict_many_sk.py
+++ b/history/management/commands/predict_many_sk.py
@@ -5,7 +5,7 @@ from history.tools import print_and_log
 from multiprocessing import Pool
 
 
-def do_prediction_test(name, ticker, data_set_inputs, granularity, min_back, timedelta_back):
+def do_classifier_test(name, ticker, data_set_inputs, granularity, min_back, timedelta_back):
     try:
         ct = ClassifierTest(name=name,
                             type='mock',
@@ -74,7 +74,7 @@ class Command(BaseCommand):
                         for timedelta_back_in_granularity_increments in \
                                 timedelta_back_in_granularity_increments_options:
                             for name in name_options:
-                                pool.apply_async(do_prediction_test, args=(
+                                pool.apply_async(do_classifier_test, args=(
                                     name,
                                     ticker,
                                     datasetinputs,

--- a/history/management/commands/predict_many_v2.py
+++ b/history/management/commands/predict_many_v2.py
@@ -24,6 +24,7 @@ def do_classifier_test(ticker, hidden_layers, min_back, epochs, granularity, dat
     except Exception as e:
         print_and_log("(p)" + str(e))
 
+
 class Command(BaseCommand):
 
     help = 'tests various settings that could make the NN more accurate'
@@ -74,7 +75,7 @@ class Command(BaseCommand):
 
         pool = Pool(settings.NUM_THREADS)
 
-        print("Starting V2 Run")
+        print("Starting V2 run")
         for ticker in ticker_options:
             for hidden_layers in hidden_layer_options:
                 for min_back in min_back_options:
@@ -97,4 +98,4 @@ class Command(BaseCommand):
         print("All V2 jobs queued")
         pool.close()
         pool.join()
-        print("V2 Run Complete")
+        print("V2 run complete")

--- a/history/management/commands/predict_many_v2.py
+++ b/history/management/commands/predict_many_v2.py
@@ -1,6 +1,10 @@
 from django.core.management.base import BaseCommand
 from history.predict import predict_v2
+from django.conf import settings
 from history.tools import print_and_log
+from multiprocessing import Pool
+
+
 class Command(BaseCommand):
 
     help = 'tests various settings that could make the NN more accurate'
@@ -13,10 +17,12 @@ class Command(BaseCommand):
         
         min_back_options = [100,1000,24*60,24*60*2] 
         # 2/22 - eliminated 10000 
-        # 2/25 -- added 24*50, 24*60*2 because "maybe because NN only contains last 1000 data points (1/3 day).  if only selling happened during taht time, nn will bias towards selling.  duh!"
+        # 2/25 -- added 24*50, 24*60*2 because "maybe because NN only contains last 1000 data points (1/3 day).
+        #   if only selling happened during that time, nn will bias towards selling.  duh!"
         
         granularity_options = [10, 15, 20, 30, 40, 50, 60, 120,240] 
-        # 2/23 notes - results so far: 59 (54% correct) 15 (56% correct) 1 (50% correct) 5 (52% correct).  removing 1,5, adding 30 . 2/23 (pt 2) -- added 119, 239
+        # 2/23 notes - results so far: 59 (54% correct) 15 (56% correct) 1 (50% correct) 5 (52% correct).
+        #   removing 1,5, adding 30 . 2/23 (pt 2) -- added 119, 239
         # 2/24 notes -- removed 120,240, added 20, 40, 45
         # 2/25 notes -- added 10, 50, removed 45
         # 2/25 -- added 120,240 back in to retest in light of recent bugs
@@ -35,7 +41,8 @@ class Command(BaseCommand):
         momentum_options = [0.1]
         
         learningrate_options = [0.05] 
-        #2/22 -- elimated 0.005, 0.01, adding 0.03 and 0.1 today.  #2/23 - 0.1 (54% correct) 0.05 (55% correct) 0.03 (54% correct) .  eliminating everything but 0.05 so i can test more #datasetinput_options
+        # 2/22 -- elimated 0.005, 0.01, adding 0.03 and 0.1 today.  #2/23 - 0.1 (54% correct) 0.05 (55% correct) 0.03
+        # (54% correct) .  eliminating everything but 0.05 so i can test more #datasetinput_options
         
         weightdecay_options = [0.0] 
         # 2/22 -- eliminated 0.1,0.2
@@ -43,33 +50,52 @@ class Command(BaseCommand):
         recurrent_options = [True] 
         # 2/23 notes - 0 (52% correct) 1 (55% correct), removed false
 
-        timedelta_back_in_granularity_increments_options = [10,30,60,100,1000]  #sets how far apart (in granularity increments) the datasets are 
-        
+        # sets how far apart (in granularity increments) the data sets are
+        timedelta_back_in_granularity_increments_options = [10,30,60,100,1000]
+
+        pool = Pool(settings.NUM_THREADS)
+
+        print("Starting V2 Run")
         for ticker in ticker_options:
             for hidden_layers in hidden_layer_options:
                 for min_back in min_back_options:
                     for epochs in epoch_options:
-                        for  granularity in granularity_options: 
+                        for granularity in granularity_options:
                             for datasetinputs in datasetinput_options:
                                 for bias in bias_options:
                                     for momentum in momentum_options:
                                         for learningrate in learningrate_options:
                                             for weightdecay in weightdecay_options:
                                                 for recurrent in recurrent_options:
-                                                    for timedelta_back_in_granularity_increments in timedelta_back_in_granularity_increments_options:
-                                                        try:
-                                                            predict_v2(ticker,
-                                                                hidden_layers=hidden_layers,
-                                                                NUM_MINUTES_BACK=min_back,
-                                                                NUM_EPOCHS=epochs,
-                                                                granularity_minutes=granularity,
-                                                                datasetinputs=datasetinputs,
-                                                                learningrate=learningrate,
-                                                                bias=bias,
-                                                                momentum=momentum,
-                                                                recurrent=recurrent,
-                                                                weightdecay=weightdecay,
-                                                                timedelta_back_in_granularity_increments=timedelta_back_in_granularity_increments)
-                                                        except Exception as e:
-                                                            print_and_log("(p)"+str(e))
-                                                    
+                                                    for timedelta_back_in_granularity_increments in \
+                                                            timedelta_back_in_granularity_increments_options:
+                                                        pool.apply_async(self._do_classifier_test, args=(
+                                                            ticker, hidden_layers, min_back, epochs, granularity,
+                                                            datasetinputs,
+                                                            learningrate, bias, momentum, recurrent, weightdecay,
+                                                            timedelta_back_in_granularity_increments
+                                                        ))
+        print("All V2 jobs queued")
+        pool.close()
+        pool.join()
+        print("V2 Run Complete")
+
+    @staticmethod
+    def _do_classifier_test(ticker, hidden_layers, min_back, epochs, granularity, datasetinputs,
+                            learningrate, bias, momentum, recurrent, weightdecay,
+                            timedelta_back_in_granularity_increments):
+        try:
+            predict_v2(ticker,
+                       hidden_layers=hidden_layers,
+                       NUM_MINUTES_BACK=min_back,
+                       NUM_EPOCHS=epochs,
+                       granularity_minutes=granularity,
+                       datasetinputs=datasetinputs,
+                       learningrate=learningrate,
+                       bias=bias,
+                       momentum=momentum,
+                       recurrent=recurrent,
+                       weightdecay=weightdecay,
+                       timedelta_back_in_granularity_increments=timedelta_back_in_granularity_increments)
+        except Exception as e:
+            print_and_log("(p)" + str(e))

--- a/history/management/commands/predict_many_v2.py
+++ b/history/management/commands/predict_many_v2.py
@@ -5,6 +5,25 @@ from history.tools import print_and_log
 from multiprocessing import Pool
 
 
+def do_classifier_test(ticker, hidden_layers, min_back, epochs, granularity, datasetinputs,
+                       learningrate, bias, momentum, recurrent, weightdecay,
+                       timedelta_back_in_granularity_increments):
+    try:
+        predict_v2(ticker,
+                   hidden_layers=hidden_layers,
+                   NUM_MINUTES_BACK=min_back,
+                   NUM_EPOCHS=epochs,
+                   granularity_minutes=granularity,
+                   datasetinputs=datasetinputs,
+                   learningrate=learningrate,
+                   bias=bias,
+                   momentum=momentum,
+                   recurrent=recurrent,
+                   weightdecay=weightdecay,
+                   timedelta_back_in_granularity_increments=timedelta_back_in_granularity_increments)
+    except Exception as e:
+        print_and_log("(p)" + str(e))
+
 class Command(BaseCommand):
 
     help = 'tests various settings that could make the NN more accurate'
@@ -69,7 +88,7 @@ class Command(BaseCommand):
                                                 for recurrent in recurrent_options:
                                                     for timedelta_back_in_granularity_increments in \
                                                             timedelta_back_in_granularity_increments_options:
-                                                        pool.apply_async(self._do_classifier_test, args=(
+                                                        pool.apply_async(do_classifier_test, args=(
                                                             ticker, hidden_layers, min_back, epochs, granularity,
                                                             datasetinputs,
                                                             learningrate, bias, momentum, recurrent, weightdecay,
@@ -79,23 +98,3 @@ class Command(BaseCommand):
         pool.close()
         pool.join()
         print("V2 Run Complete")
-
-    @staticmethod
-    def _do_classifier_test(ticker, hidden_layers, min_back, epochs, granularity, datasetinputs,
-                            learningrate, bias, momentum, recurrent, weightdecay,
-                            timedelta_back_in_granularity_increments):
-        try:
-            predict_v2(ticker,
-                       hidden_layers=hidden_layers,
-                       NUM_MINUTES_BACK=min_back,
-                       NUM_EPOCHS=epochs,
-                       granularity_minutes=granularity,
-                       datasetinputs=datasetinputs,
-                       learningrate=learningrate,
-                       bias=bias,
-                       momentum=momentum,
-                       recurrent=recurrent,
-                       weightdecay=weightdecay,
-                       timedelta_back_in_granularity_increments=timedelta_back_in_granularity_increments)
-        except Exception as e:
-            print_and_log("(p)" + str(e))

--- a/history/management/commands/predict_many_v2.py
+++ b/history/management/commands/predict_many_v2.py
@@ -5,7 +5,7 @@ from history.tools import print_and_log
 from multiprocessing import Pool
 
 
-def do_classifier_test(ticker, hidden_layers, min_back, epochs, granularity, datasetinputs,
+def do_prediction_test(ticker, hidden_layers, min_back, epochs, granularity, datasetinputs,
                        learningrate, bias, momentum, recurrent, weightdecay,
                        timedelta_back_in_granularity_increments):
     try:
@@ -89,7 +89,7 @@ class Command(BaseCommand):
                                                 for recurrent in recurrent_options:
                                                     for timedelta_back_in_granularity_increments in \
                                                             timedelta_back_in_granularity_increments_options:
-                                                        pool.apply_async(do_classifier_test, args=(
+                                                        pool.apply_async(do_prediction_test, args=(
                                                             ticker, hidden_layers, min_back, epochs, granularity,
                                                             datasetinputs,
                                                             learningrate, bias, momentum, recurrent, weightdecay,

--- a/history/tools.py
+++ b/history/tools.py
@@ -3,10 +3,10 @@ import datetime
 from django.conf import settings
 
 
-def print_and_log(str):
+def print_and_log(log_string):
     with open(settings.LOG_FILE, "a") as myfile:
-        myfile.write(str+"\n")
-    print(str)    
+        myfile.write(log_string + "\n")
+    print(log_string)
 
 def get_utc_unixtime():
     import time

--- a/pypolo/settings.py
+++ b/pypolo/settings.py
@@ -119,6 +119,9 @@ STATICFILES_DIRS = [
 # logfile
 LOG_FILE = "/var/log/django.log"
 
+# Default number of threads for workers
+NUM_THREADS = 1
+
 # Include local settings overrides
 try:
     from pypolo.local_settings import *  # NOQA

--- a/readme.md
+++ b/readme.md
@@ -155,7 +155,7 @@ SMTP_PASSWORD = '<smtp_pass>'
 LOG_FILE = '/var/log/django.log'
 
 # Configuration of the number of threads to be used for predictions - Set to CPU cores + 1 if dedicated machine
-MAX_THREADS = 5
+NUM_THREADS = 5
 ```
 
 install your requirements

--- a/readme.md
+++ b/readme.md
@@ -153,6 +153,9 @@ SMTP_USERNAME = '<smtp_user>'
 SMTP_PASSWORD = '<smtp_pass>'
 
 LOG_FILE = '/var/log/django.log'
+
+# Configuration of the number of threads to be used for predictions - Set to CPU cores + 1 if dedicated machine
+MAX_THREADS = 5
 ```
 
 install your requirements


### PR DESCRIPTION
Added multithreading/pool support on the two main generation functions.  This allows for a linear speedup of x/NUM_THREADS as defined in the local_settings.py.

Updated readme.MD to reference the new required setting - May be worth adding as a default to the main settings.py?

Running this in a docker environment with PostgreSQL on a SSD.

predict_many_v2 is still running in the background right now, once it's done, I'll provide some time stats.

Machine Stats:
2x Intel(R) Xeon(R) CPU           L5639  @ 2.13GHz
72Gb ram

Runtimes:
Running with 24 threads:
- predict_many_sk:
  - real 2m 7.850s
  - user 27m 25.829s
  - sys 1m 41.492s

Non-threaded:
- predict_many_sk:
  - real 32m 2.854s
  - user 22m 5.785s
  - sys 0m 44.857s
