### PR TITLE
ARAC Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN git clone git://github.com/bayerj/arac.git /root/arac && \
     cd /root/arac/ && \
     sed -i "s/.*test.*//i" SConstruct && \
     scons && \
-    cp libarac.so /usr/lib/
+    cp libarac.so /usr/lib/ && \
+    cd /root/
 
 ENV PYTHONPATH=/root/arac/src/python

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,16 @@ RUN apt-get update && apt-get install -y \
         libatlas-base-dev \
         gfortran \
         cron \
+        swig \
     --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /requirements.txt
 RUN pip install --no-cache-dir -r /requirements.txt
 
+RUN git clone git://github.com/bayerj/arac.git /root/arac && \
+    cd /root/arac/ && \
+    sed -i "s/.*test.*//i" SConstruct && \
+    scons && \
+    cp libarac.so /usr/lib/
+
+ENV PYTHONPATH=/root/arac/src/python

--- a/history/models.py
+++ b/history/models.py
@@ -505,7 +505,12 @@ class PredictionTest(AbstractedTesterClass):
         train_data, results_data = self.get_train_and_test_data()
         DS = self.create_DS(train_data)
 
-        FNN = buildNetwork(DS.indim, self.hiddenneurons, DS.outdim, bias=self.bias, recurrent=self.recurrent)
+        try:
+            import arac
+            FNN = buildNetwork(DS.indim, self.hiddenneurons, DS.outdim, bias=self.bias, recurrent=self.recurrent,
+                               fast=True)
+        except ImportError:
+            FNN = buildNetwork(DS.indim, self.hiddenneurons, DS.outdim, bias=self.bias, recurrent=self.recurrent)
         FNN.randomize()
         
         TRAINER = BackpropTrainer(FNN, dataset=DS, learningrate = self.learningrate, \

--- a/history/models.py
+++ b/history/models.py
@@ -507,6 +507,7 @@ class PredictionTest(AbstractedTesterClass):
 
         try:
             import arac
+            print("ARAC Available, using fast mode network builder!")
             FNN = buildNetwork(DS.indim, self.hiddenneurons, DS.outdim, bias=self.bias, recurrent=self.recurrent,
                                fast=True)
         except ImportError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ simplejson==3.8.2
 Cython==0.23.5
 sklearn==0.0
 supervisor==3.2.3
+sc0ns==2.2.0.post1


### PR DESCRIPTION
This adds support for ARAC.  Per:
https://github.com/owocki/pytrader/issues/46

Testing shows approximately a 33% speedup for all NN related task.  This will likely include the trade system itself as it's using v2 stats, which is where we're seeing the speedup.

This is currently backwards compatible with current installs, if we're unable to import ARAC, it fails cleanly.  The docker build has been updated to support this system.