### PR TITLE
Moves NN / classifier trainers & trader information to a place where they can be overridden privately

### DIFF
--- a/history/management/commands/compare_perf.py
+++ b/history/management/commands/compare_perf.py
@@ -4,55 +4,55 @@ from django.conf import settings
 from history.models import Price, TradeRecommendation, PerformanceComp
 import datetime
 from django.db import transaction
+
+
 class Command(BaseCommand):
 
     help = 'compares market perf vs nn_perf'
 
     def handle(self, *args, **options):
-        #setup
+        # setup
         buffer_between_prediction_and_this_script_mins = datetime.datetime.now().minute % 10
-        granularity_mins = 10 #TODO: change me when granularity changes
+        granularity_mins = settings.TRADER_GRANULARITY_MINS
         ticker = 'BTC_ETH'
 
-        #get data
-        date_of_timerange_we_care_about_predictions_start = datetime.datetime.now() - datetime.timedelta(seconds=((granularity_mins)*60+(60*(1+buffer_between_prediction_and_this_script_mins))))
-        date_of_timerange_we_care_about_predictions_end = datetime.datetime.now() - datetime.timedelta(seconds=((granularity_mins)*60))
-        tr_timerange_end = TradeRecommendation.objects.filter(symbol=ticker,created_on__gte=date_of_timerange_we_care_about_predictions_start,created_on__lte=date_of_timerange_we_care_about_predictions_end).order_by('-created_on').first().created_on
+        # get data
+        date_of_timerange_we_care_about_predictions_start = datetime.datetime.now() - datetime.timedelta(seconds=((granularity_mins) * 60 + (60 * (1 + buffer_between_prediction_and_this_script_mins))))
+        date_of_timerange_we_care_about_predictions_end = datetime.datetime.now() - datetime.timedelta(seconds=((granularity_mins) * 60))
+        tr_timerange_end = TradeRecommendation.objects.filter(symbol=ticker, created_on__gte=date_of_timerange_we_care_about_predictions_start, created_on__lte=date_of_timerange_we_care_about_predictions_end).order_by('-created_on').first().created_on
         tr_timerange_start = tr_timerange_end - datetime.timedelta(seconds=120)
         price_timerange_start = tr_timerange_end
-        price_timerange_end = tr_timerange_end + datetime.timedelta(seconds=(granularity_mins*60))
-        trs = TradeRecommendation.objects.filter(created_on__gte=tr_timerange_start,created_on__lte=tr_timerange_end)
-        price_now = Price.objects.filter(symbol=ticker,created_on__lte=price_timerange_end).order_by('-created_on').first().price
-        price_then = Price.objects.filter(symbol=ticker,created_on__lte=price_timerange_start).order_by('-created_on').first().price
+        price_timerange_end = tr_timerange_end + datetime.timedelta(seconds=(granularity_mins * 60))
+        trs = TradeRecommendation.objects.filter(created_on__gte=tr_timerange_start, created_on__lte=tr_timerange_end)
+        price_now = Price.objects.filter(symbol=ticker, created_on__lte=price_timerange_end).order_by('-created_on').first().price
+        price_then = Price.objects.filter(symbol=ticker, created_on__lte=price_timerange_start).order_by('-created_on').first().price
 
-        ## nn attributes
-        pct_buy = round(1.0 * sum(tr.recommendation == 'BUY' for tr in trs) / len(trs),2)
-        pct_sell = round(1.0 * sum(tr.recommendation == 'SELL' for tr in trs) / len(trs),2)
-        pct_hold = round(1.0 * sum(tr.recommendation == 'HOLD' for tr in trs) / len(trs),2)
+        # nn attributes
+        pct_buy = round(1.0 * sum(tr.recommendation == 'BUY' for tr in trs) / len(trs), 2)
+        pct_sell = round(1.0 * sum(tr.recommendation == 'SELL' for tr in trs) / len(trs), 2)
+        pct_hold = round(1.0 * sum(tr.recommendation == 'HOLD' for tr in trs) / len(trs), 2)
         price_diff = price_now - price_then
         price_pct = price_diff / price_then
-        price_buy_hold_sell = 0 if abs(price_pct) < 0.002 else ( 1 if price_pct > 0 else -1 ) #-1 = sell, 0 = hold, 1 = wait
+        price_buy_hold_sell = 0 if abs(price_pct) < 0.002 else (1 if price_pct > 0 else -1)  # -1 = sell, 0 = hold, 1 = wait
         avg_nn_rec = 1.0 * sum(tr.net_amount for tr in trs) / len(trs)
-        weighted_avg_nn_rec = 1.0 * sum(tr.net_amount * (tr.confidence/100.0) for tr in trs) / len(trs)
+        weighted_avg_nn_rec = 1.0 * sum(tr.net_amount * (tr.confidence / 100.0) for tr in trs) / len(trs)
         directionally_same = ((avg_nn_rec > 0 and price_buy_hold_sell > 0) or (avg_nn_rec < 0 and price_buy_hold_sell < 0))
-        delta = abs(abs(avg_nn_rec) - abs(price_buy_hold_sell)) * ( 1 if directionally_same else -1  )
+        delta = abs(abs(avg_nn_rec) - abs(price_buy_hold_sell)) * (1 if directionally_same else -1)
 
         pc = PerformanceComp(symbol=ticker,
-            price_timerange_start=price_timerange_start,
-            price_timerange_end=price_timerange_end,
-            tr_timerange_start=tr_timerange_start,
-            tr_timerange_end=tr_timerange_end,
-            nn_rec=avg_nn_rec,
-            actual_movement=price_buy_hold_sell,
-            delta=delta,
-            pct_buy=pct_buy,
-            pct_sell=pct_sell,
-            pct_hold=pct_hold,
-            rec_count=trs.count(),
-            weighted_avg_nn_rec=weighted_avg_nn_rec,
-            directionally_same=directionally_same,
-            directionally_same_int=1 if directionally_same else 0,
-            created_on_str=(tr_timerange_end-datetime.timedelta(hours=7)).strftime('%Y-%m-%d %H:%M'))
+                             price_timerange_start=price_timerange_start,
+                             price_timerange_end=price_timerange_end,
+                             tr_timerange_start=tr_timerange_start,
+                             tr_timerange_end=tr_timerange_end,
+                             nn_rec=avg_nn_rec,
+                             actual_movement=price_buy_hold_sell,
+                             delta=delta,
+                             pct_buy=pct_buy,
+                             pct_sell=pct_sell,
+                             pct_hold=pct_hold,
+                             rec_count=trs.count(),
+                             weighted_avg_nn_rec=weighted_avg_nn_rec,
+                             directionally_same=directionally_same,
+                             directionally_same_int=1 if directionally_same else 0,
+                             created_on_str=(tr_timerange_end - datetime.timedelta(hours=7)).strftime('%Y-%m-%d %H:%M'))
         pc.save()
-
-

--- a/history/management/commands/predict_many_sk.py
+++ b/history/management/commands/predict_many_sk.py
@@ -46,34 +46,16 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
 
-        ticker_options = ['BTC_ETH', 'USDT_BTC']
-
-        min_back_options = [100, 1000, 24 * 60, 24 * 60 * 2]
-
-        granularity_options = [10, 15, 20, 30, 40, 50, 60, 120, 240]
-        if not settings.MAKE_TRADES:
-            granularity_options = [1]
-
-        datasetinput_options = [2]
-        # TODO: enable more than just 1 type
-
-        # sets how far apart (in granularity increments) the datasets are
-        timedelta_back_in_granularity_increments_options = [10, 30, 60, 100, 1000]
-
-        name_options = ["Nearest Neighbors", "Linear SVM", "RBF SVM", "Decision Tree",
-                        "Random Forest", "AdaBoost", "Naive Bayes", "Linear Discriminant Analysis",
-                        "Quadratic Discriminant Analysis"]
-
         pool = Pool(settings.NUM_THREADS)
-
+        conf = settings.TRAINER_CURRENCY_CONFIG['classifiers']
         print("Starting SK run")
-        for ticker in ticker_options:
-            for min_back in min_back_options:
-                for granularity in granularity_options:
-                    for datasetinputs in datasetinput_options:
+        for ticker in conf['ticker']:
+            for min_back in conf['min_back']:
+                for granularity in conf['granularity']:
+                    for datasetinputs in conf['datasetinputs']:
                         for timedelta_back_in_granularity_increments in \
-                                timedelta_back_in_granularity_increments_options:
-                            for name in name_options:
+                                conf['timedelta_back_in_granularity_increments']:
+                            for name in conf['name']:
                                 pool.apply_async(do_classifier_test, args=(
                                     name,
                                     ticker,

--- a/history/management/commands/predict_many_v2.py
+++ b/history/management/commands/predict_many_v2.py
@@ -30,65 +30,24 @@ class Command(BaseCommand):
     help = 'tests various settings that could make the NN more accurate'
 
     def handle(self, *args, **options):
-        ticker_options = ['BTC_ETH','USDT_BTC']
-        hidden_layer_options = [1,5, 15, 40] 
-        # 2/23 -- removed 15, it was barely edged out by 1,5.
-        # 2/25 -- added 15, 40 in because of recent bugs
-        
-        min_back_options = [100,1000,24*60,24*60*2] 
-        # 2/22 - eliminated 10000 
-        # 2/25 -- added 24*50, 24*60*2 because "maybe because NN only contains last 1000 data points (1/3 day).
-        #   if only selling happened during that time, nn will bias towards selling.  duh!"
-        
-        granularity_options = [10, 15, 20, 30, 40, 50, 60, 120,240] 
-        # 2/23 notes - results so far: 59 (54% correct) 15 (56% correct) 1 (50% correct) 5 (52% correct).
-        #   removing 1,5, adding 30 . 2/23 (pt 2) -- added 119, 239
-        # 2/24 notes -- removed 120,240, added 20, 40, 45
-        # 2/25 notes -- added 10, 50, removed 45
-        # 2/25 -- added 120,240 back in to retest in light of recent bugs
-
-        datasetinput_options = [1,2,3,4,5,6, 15,10,20,40,100, 200] 
-        # 2/23 -- removed 3,5,15 -- added 20,40,100
-        # 2/24 -- removed 7,10,20,40,100, added 3,4,5
-        # 2/25 -- added 3,5,15,10,20,40,100 back in to retest in light of recent bugs
-
-        epoch_options = [1000] 
-        # 2/22 -- eliminated 4000, 100
-        
-        bias_options = [True] 
-        # 2/22 -- Eliminated 'False'
-        
-        momentum_options = [0.1]
-        
-        learningrate_options = [0.05] 
-        # 2/22 -- elimated 0.005, 0.01, adding 0.03 and 0.1 today.  #2/23 - 0.1 (54% correct) 0.05 (55% correct) 0.03
-        # (54% correct) .  eliminating everything but 0.05 so i can test more #datasetinput_options
-        
-        weightdecay_options = [0.0] 
-        # 2/22 -- eliminated 0.1,0.2
-        
-        recurrent_options = [True] 
-        # 2/23 notes - 0 (52% correct) 1 (55% correct), removed false
-
-        # sets how far apart (in granularity increments) the data sets are
-        timedelta_back_in_granularity_increments_options = [10,30,60,100,1000]
 
         pool = Pool(settings.NUM_THREADS)
+        conf = settings.TRAINER_CURRENCY_CONFIG['supervised_nn']
 
         print("Starting V2 run")
-        for ticker in ticker_options:
-            for hidden_layers in hidden_layer_options:
-                for min_back in min_back_options:
-                    for epochs in epoch_options:
-                        for granularity in granularity_options:
-                            for datasetinputs in datasetinput_options:
-                                for bias in bias_options:
-                                    for momentum in momentum_options:
-                                        for learningrate in learningrate_options:
-                                            for weightdecay in weightdecay_options:
-                                                for recurrent in recurrent_options:
+        for ticker in conf['ticker']:
+            for hidden_layers in conf['hidden_layers']:
+                for min_back in conf['min_back']:
+                    for epochs in conf['epochs']:
+                        for granularity in conf['granularity']:
+                            for datasetinputs in conf['datasetinputs']:
+                                for bias in conf['bias']:
+                                    for momentum in conf['momentum']:
+                                        for learningrate in conf['learningrate']:
+                                            for weightdecay in conf['weightdecay']:
+                                                for recurrent in conf['recurrent']:
                                                     for timedelta_back_in_granularity_increments in \
-                                                            timedelta_back_in_granularity_increments_options:
+                                                            conf['timedelta_back_in_granularity_increments']:
                                                         pool.apply_async(do_prediction_test, args=(
                                                             ticker, hidden_layers, min_back, epochs, granularity,
                                                             datasetinputs,

--- a/history/management/commands/trade.py
+++ b/history/management/commands/trade.py
@@ -22,41 +22,7 @@ class Command(BaseCommand):
         granularity = 10  # TODO: change me when granularity changes (search this string <---)
         if not settings.MAKE_TRADES:
             granularity = 1
-        self.predictor_configs = [
-            {'type': 'nn',
-                'name': 'ETH / 5',
-                'symbol': 'BTC_ETH',
-                'weight': 0.1,
-                'granularity': granularity,
-                'datasetinputs': 5},
-            {'type': 'nn',
-                'name': 'ETH / 5',
-                'symbol': 'BTC_ETH',
-                'weight': 0.1,
-                'granularity': granularity,
-                'datasetinputs': 4},
-            {'type': 'classifier',
-                'symbol': 'USDT_BTC',
-                'name': 'AdaBoost',
-                'weight': 0.1,
-                'granularity': granularity,
-                'datasetinputs': 2,
-                'minutes_back': 1000},
-            {'type': 'classifier',
-                'symbol': 'USDT_BTC',
-                'name': 'Naive Bayes',
-                'weight': 0.1,
-                'granularity': granularity,
-                'datasetinputs': 2,
-                'minutes_back': 1000},
-            {'type': 'classifier',
-                'symbol': 'BTC_ETH',
-                'name': 'Naive Bayes',
-                'weight': 2,
-                'granularity': granularity * 3,
-                'datasetinputs': 2,
-                'minutes_back': 1000},
-        ]
+        self.predictor_configs = settings.TRADER_CURRENCY_CONFIG
 
     def handle_open_orders(self):
 

--- a/history/models.py
+++ b/history/models.py
@@ -5,7 +5,7 @@ from pybrain.datasets import SupervisedDataSet
 from pybrain.tools.shortcuts import buildNetwork
 from pybrain.supervised.trainers import BackpropTrainer
 from django.db import models
-from history.tools import create_sample_row, npc
+from history.tools import create_sample_row
 from django.utils.timezone import localtime
 from django.conf import settings
 import time
@@ -339,7 +339,7 @@ class ClassifierTest(AbstractedTesterClass):
             for i in range(0,self.datasetinputs):
                 self.ravel_args.append(self.xz[i].ravel())
 
-            self._input = npc(self.ravel_args)
+            self._input = np.column_stack(self.ravel_args)
             
             if hasattr(clf, "decision_function"):
                 self.Z = clf.decision_function(self._input)

--- a/history/tools.py
+++ b/history/tools.py
@@ -127,34 +127,3 @@ def get_deposit_balance():
         usd_deposit_amount = usd_deposit_amount + usd_amount
     return btc_deposit_amount, usd_deposit_amount
 
-
-def npc(args):
-    # hack to enter multiple args into np.c_
-    if len(args) == 1:
-        return np.c_[args[0]]
-    if len(args) == 2:
-        return np.c_[args[0], args[1]]
-    if len(args) == 3:
-        return np.c_[args[0], args[1], args[2]]
-    if len(args) == 4:
-        return np.c_[args[0], args[1], args[2], args[3]]
-    if len(args) == 5:
-        return np.c_[args[0], args[1], args[2], args[3], args[4]]
-    if len(args) == 6:
-        return np.c_[args[0], args[1], args[2], args[3], args[4], args[5]]
-    if len(args) == 7:
-        return np.c_[args[0], args[1], args[2], args[3], args[4], args[5], args[6]]
-    if len(args) == 8:
-        return np.c_[args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7]]
-    if len(args) == 9:
-        return np.c_[args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8]]
-    if len(args) == 10:
-        return np.c_[args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9]]
-    if len(args) == 11:
-        return np.c_[args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9], args[10]]
-    if len(args) == 12:
-        return np.c_[args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9], args[10], args[11]]
-    if len(args) == 13:
-        return np.c_[args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9], args[10], args[11], args[12]]
-
-    raise NotImplementedError()

--- a/history/tools.py
+++ b/history/tools.py
@@ -1,12 +1,14 @@
 import time
 import datetime
 from django.conf import settings
+import numpy as np
 
 
 def print_and_log(log_string):
     with open(settings.LOG_FILE, "a") as myfile:
         myfile.write(log_string + "\n")
     print(log_string)
+
 
 def get_utc_unixtime():
     import time
@@ -16,10 +18,11 @@ def get_utc_unixtime():
     unixtime = time.mktime(d.timetuple())
     return int(unixtime)
 
-def create_sample_row(data,i,size):
+
+def create_sample_row(data, i, size):
     sample = ()
-    for k in range(0,size):
-        sample = sample + (data[i+k],)
+    for k in range(0, size):
+        sample = sample + (data[i + k],)
     return sample
 
 
@@ -44,36 +47,39 @@ def normalization(data, new_max=1, new_min=0):
             data[i] = (((data[i] - old_min) * new_range) / old_range) + new_min
     return data
 
-def filter_by_mins(data,mins=5):
+
+def filter_by_mins(data, mins=5):
     new_data = []
 
     for ele in data:
         ele_unixtime = int(time.mktime(ele.created_on.timetuple()))
-        ele_unixtime_min = int(ele_unixtime/60)
+        ele_unixtime_min = int(ele_unixtime / 60)
         if ele_unixtime_min % mins == 0:
             new_data.append(ele)
 
     return new_data
 
+
 def median_value(queryset, term):
     count = queryset.count()
-    return queryset.values_list(term, flat=True).order_by(term)[int(round(count/2))]
+    return queryset.values_list(term, flat=True).order_by(term)[int(round(count / 2))]
 
-def get_exchange_rate_to_btc(ticker,d=None):
+
+def get_exchange_rate_to_btc(ticker, d=None):
     from history.models import Price
-    
+
     if d is None:
         d = datetime.datetime.now()
     if ticker == 'BTC':
         return 1
-    
+
     try:
-        exchange_pair = 'BTC_'+ticker
-        latest_price = Price.objects.filter(symbol=exchange_pair,created_on__lt=d).order_by('-created_on').first()
+        exchange_pair = 'BTC_' + ticker
+        latest_price = Price.objects.filter(symbol=exchange_pair, created_on__lt=d).order_by('-created_on').first()
         return latest_price.price
     except:
         exchange_pair = ticker + '_BTC'
-        latest_price = Price.objects.filter(symbol=exchange_pair,created_on__lt=d).order_by('-created_on').first()
+        latest_price = Price.objects.filter(symbol=exchange_pair, created_on__lt=d).order_by('-created_on').first()
         return 1.0 / latest_price.price
 
 
@@ -83,39 +89,72 @@ def get_exchange_rate_btc_to_usd(d=None):
         d = datetime.datetime.now()
 
     exchange_pair = 'USDT_BTC'
-    latest_price = Price.objects.filter(symbol=exchange_pair,created_on__lt=d).order_by('-created_on').first()
+    latest_price = Price.objects.filter(symbol=exchange_pair, created_on__lt=d).order_by('-created_on').first()
     return latest_price.price
 
-def get_cost_basis(total_amount,symbol):
+
+def get_cost_basis(total_amount, symbol):
     from history.models import Trade
     running_amount = total_amount
     cost_basis_array = []
-    ts = Trade.objects.filter(symbol=symbol).order_by('-created_on').values_list('amount','price')
+    ts = Trade.objects.filter(symbol=symbol).order_by('-created_on').values_list('amount', 'price')
     for t in ts:
         if running_amount < 0:
             continue
         trade_amount = t[0]
         price = t[1]
         if running_amount < trade_amount:
-            cost_basis_array.append([running_amount,price])
+            cost_basis_array.append([running_amount, price])
         else:
-            cost_basis_array.append([trade_amount,price])
+            cost_basis_array.append([trade_amount, price])
         running_amount = running_amount - trade_amount
 
-    total_amount = sum([ t[0] for t in cost_basis_array])
-    total_paid = sum([ t[0] * t[1] for t in cost_basis_array])
+    total_amount = sum([t[0] for t in cost_basis_array])
+    total_paid = sum([t[0] * t[1] for t in cost_basis_array])
 
-    return  total_paid / total_amount
+    return total_paid / total_amount
+
 
 def get_deposit_balance():
     from history.models import Deposit
     btc_deposit_amount = 0
     usd_deposit_amount = 0
     for d in Deposit.objects.all():
-        exchange_rate = get_exchange_rate_to_btc(d.symbol,d.created_on)
+        exchange_rate = get_exchange_rate_to_btc(d.symbol, d.created_on)
         btc_amount = d.amount * exchange_rate
         usd_amount = get_exchange_rate_btc_to_usd(d.created_on) * btc_amount
         btc_deposit_amount = btc_deposit_amount + btc_amount
         usd_deposit_amount = usd_deposit_amount + usd_amount
     return btc_deposit_amount, usd_deposit_amount
 
+
+def npc(args):
+    # hack to enter multiple args into np.c_
+    if len(args) == 1:
+        return np.c_[args[0]]
+    if len(args) == 2:
+        return np.c_[args[0], args[1]]
+    if len(args) == 3:
+        return np.c_[args[0], args[1], args[2]]
+    if len(args) == 4:
+        return np.c_[args[0], args[1], args[2], args[3]]
+    if len(args) == 5:
+        return np.c_[args[0], args[1], args[2], args[3], args[4]]
+    if len(args) == 6:
+        return np.c_[args[0], args[1], args[2], args[3], args[4], args[5]]
+    if len(args) == 7:
+        return np.c_[args[0], args[1], args[2], args[3], args[4], args[5], args[6]]
+    if len(args) == 8:
+        return np.c_[args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7]]
+    if len(args) == 9:
+        return np.c_[args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8]]
+    if len(args) == 10:
+        return np.c_[args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9]]
+    if len(args) == 11:
+        return np.c_[args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9], args[10]]
+    if len(args) == 12:
+        return np.c_[args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9], args[10], args[11]]
+    if len(args) == 13:
+        return np.c_[args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9], args[10], args[11], args[12]]
+
+    raise NotImplementedError()

--- a/pypolo/settings.py
+++ b/pypolo/settings.py
@@ -165,7 +165,7 @@ TRAINER_CURRENCY_CONFIG = {
         'ticker': ['BTC_ETH', 'USDT_BTC'],
         'min_back': [100, 1000, 24 * 60, 24 * 60 * 2],
         'granularity': [10, 15, 20, 30, 40, 50, 60, 120, 240],
-        'datasetinputs': [3],
+        'datasetinputs': [2, 3, 5],
         'timedelta_back_in_granularity_increments': [10, 30, 60, 100, 1000],
         'name': ["Nearest Neighbors", "Linear SVM", "RBF SVM", "Decision Tree",
                  "Random Forest", "AdaBoost", "Naive Bayes", "Linear Discriminant Analysis",

--- a/pypolo/settings.py
+++ b/pypolo/settings.py
@@ -122,7 +122,7 @@ LOG_FILE = "/var/log/django.log"
 # Default number of threads for workers
 NUM_THREADS = 1
 
-TRADER_GRANULARITY_MINS= 10  # TODO: change me when granularity changes (search this string <---)
+TRADER_GRANULARITY_MINS = 10  # TODO: change me when granularity changes (search this string <---)
 
 TRADER_CURRENCY_CONFIG = [
     {'type': 'nn',
@@ -165,7 +165,7 @@ TRAINER_CURRENCY_CONFIG = {
         'ticker': ['BTC_ETH', 'USDT_BTC'],
         'min_back': [100, 1000, 24 * 60, 24 * 60 * 2],
         'granularity': [10, 15, 20, 30, 40, 50, 60, 120, 240],
-        'datasetinputs': [2], # TODO: enable more than just 1 type
+        'datasetinputs': [3],
         'timedelta_back_in_granularity_increments': [10, 30, 60, 100, 1000],
         'name': ["Nearest Neighbors", "Linear SVM", "RBF SVM", "Decision Tree",
                  "Random Forest", "AdaBoost", "Naive Bayes", "Linear Discriminant Analysis",

--- a/pypolo/settings.py
+++ b/pypolo/settings.py
@@ -165,7 +165,7 @@ TRAINER_CURRENCY_CONFIG = {
         'ticker': ['BTC_ETH', 'USDT_BTC'],
         'min_back': [100, 1000, 24 * 60, 24 * 60 * 2],
         'granularity': [10, 15, 20, 30, 40, 50, 60, 120, 240],
-        'datasetinputs': [2],
+        'datasetinputs': [2], # TODO: enable more than just 1 type
         'timedelta_back_in_granularity_increments': [10, 30, 60, 100, 1000],
         'name': ["Nearest Neighbors", "Linear SVM", "RBF SVM", "Decision Tree",
                  "Random Forest", "AdaBoost", "Naive Bayes", "Linear Discriminant Analysis",

--- a/pypolo/settings.py
+++ b/pypolo/settings.py
@@ -122,6 +122,90 @@ LOG_FILE = "/var/log/django.log"
 # Default number of threads for workers
 NUM_THREADS = 1
 
+TRADER_GRANULARITY_MINS= 10  # TODO: change me when granularity changes (search this string <---)
+
+TRADER_CURRENCY_CONFIG = [
+    {'type': 'nn',
+     'name': 'ETH / 5',
+     'symbol': 'BTC_ETH',
+     'weight': 0.1,
+     'granularity': TRADER_GRANULARITY_MINS,
+     'datasetinputs': 5},
+    {'type': 'nn',
+     'name': 'ETH / 5',
+     'symbol': 'BTC_ETH',
+     'weight': 0.1,
+     'granularity': TRADER_GRANULARITY_MINS,
+     'datasetinputs': 4},
+    {'type': 'classifier',
+     'symbol': 'USDT_BTC',
+     'name': 'AdaBoost',
+     'weight': 0.1,
+     'granularity': TRADER_GRANULARITY_MINS,
+     'datasetinputs': 2,
+     'minutes_back': 1000},
+    {'type': 'classifier',
+     'symbol': 'USDT_BTC',
+     'name': 'Naive Bayes',
+     'weight': 0.1,
+     'granularity': TRADER_GRANULARITY_MINS,
+     'datasetinputs': 2,
+     'minutes_back': 1000},
+    {'type': 'classifier',
+     'symbol': 'BTC_ETH',
+     'name': 'Naive Bayes',
+     'weight': 2,
+     'granularity': TRADER_GRANULARITY_MINS * 3,
+     'datasetinputs': 2,
+     'minutes_back': 1000},
+]
+
+TRAINER_CURRENCY_CONFIG = {
+    'classifiers': {
+        'ticker': ['BTC_ETH', 'USDT_BTC'],
+        'min_back': [100, 1000, 24 * 60, 24 * 60 * 2],
+        'granularity': [10, 15, 20, 30, 40, 50, 60, 120, 240],
+        'datasetinputs': [2],
+        'timedelta_back_in_granularity_increments': [10, 30, 60, 100, 1000],
+        'name': ["Nearest Neighbors", "Linear SVM", "RBF SVM", "Decision Tree",
+                 "Random Forest", "AdaBoost", "Naive Bayes", "Linear Discriminant Analysis",
+                 "Quadratic Discriminant Analysis"],
+    },
+    'supervised_nn': {
+        'ticker': ['BTC_ETH', 'USDT_BTC'],
+        'hidden_layer': [1, 5, 15, 40],
+        # 2/23 -- removed 15, it was barely edged out by 1,5.
+        # 2/25 -- added 15, 40 in because of recent bugs
+        'min_back': [100, 1000, 24 * 60, 24 * 60 * 2],
+        # 2/22 - eliminated 10000
+        # 2/25 -- added 24*50, 24*60*2 because "maybe because NN only contains last 1000 data points (1/3 day).
+        #   if only selling happened during that time, nn will bias towards selling.  duh!"
+        'granularity': [10, 15, 20, 30, 40, 50, 60, 120, 240],
+        # 2/23 notes - results so far: 59 (54% correct) 15 (56% correct) 1 (50% correct) 5 (52% correct).
+        #   removing 1,5, adding 30 . 2/23 (pt 2) -- added 119, 239
+        # 2/24 notes -- removed 120,240, added 20, 40, 45
+        # 2/25 notes -- added 10, 50, removed 45
+        # 2/25 -- added 120,240 back in to retest in light of recent bugs
+        'datasetinput': [1, 2, 3, 4, 5, 6, 15, 10, 20, 40, 100, 200],
+        # 2/23 -- removed 3,5,15 -- added 20,40,100
+        # 2/24 -- removed 7,10,20,40,100, added 3,4,5
+        # 2/25 -- added 3,5,15,10,20,40,100 back in to retest in light of recent bugs
+        'epoch': [1000],
+        # 2/22 -- eliminated 4000, 100
+        'bias': [True],
+        # 2/22 -- Eliminated 'False'
+        'momentum': [0.1],
+        'learningrate': [0.05],
+        # 2/22 -- elimated 0.005, 0.01, adding 0.03 and 0.1 today.  #2/23 - 0.1 (54% correct) 0.05 (55% correct) 0.03
+        # (54% correct) .  eliminating everything but 0.05 so i can test more #datasetinput_options
+        'weightdecay': [0.0],
+        # 2/22 -- eliminated 0.1,0.2
+        'recurrent': [True],
+        # 2/23 notes - 0 (52% correct) 1 (55% correct), removed false
+        'timedelta_back_in_granularity_increments': [10, 30, 60, 100, 1000],
+    }
+}
+
 # Include local settings overrides
 try:
     from pypolo.local_settings import *  # NOQA


### PR DESCRIPTION
Wrote this up last night.  Finally got around to submitting it as a PR.
# What

Moves NN / classifier trainers & trader information to a place where they can be overridden privately: `settings.py`.

This allows contributors to tune their own settings AND contribute back to the main fork without having to juggle a bunch of `git stash`s.

Note: also some linting in this PR.  Sorry, linter went crazy :P
# Why

See https://github.com/owocki/pytrader/issues/36
# img

<img src='http://bits.owocki.com/030N0t100M29/Image%202016-04-05%20at%204.59.45%20PM.png' />
