### PR TITLE
Update to fix docker requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,10 @@ RUN apt-get update && apt-get install -y \
         swig \
     --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
+RUN pip install numpy==1.7.1
+RUN pip install scipy==0.13.3
+RUN pip install matplotlib==1.3.1
+
 COPY requirements.txt /requirements.txt
 RUN pip install --no-cache-dir -r /requirements.txt
 

--- a/docker/crontab_docker.txt
+++ b/docker/crontab_docker.txt
@@ -1,0 +1,11 @@
+# m h  dom mon dow   command
+* * * * * #source /tmp/.app.env; cd pytrader; ./manage.py runserver $IP_ADDRESS:80 #KO NOTES -- This is done in a while loop in a screen now
+1 1 * * * #source /tmp/.app.env; cd pytrader; ./manage.py predict_many_v2  #KO NOTES -- This is done in a while loop in a screen now
+1 1 * * * #source /tmp/.app.env; cd pytrader; ./manage.py predict_many_sk  #KO NOTES -- This is done in a while loop in a screen now
+*/30 * * * * source /tmp/.app.env; cd pytrader; ./manage.py alert_fail_cases
+* * * * * source /tmp/.app.env; cd pytrader; ./manage.py pull_prices
+1 */6 * * * source /tmp/.app.env; cd pytrader; ./manage.py pull_deposits
+*/5 * * * * source /tmp/.app.env; cd pytrader; ./manage.py pull_balance
+*/5 * * * * source /tmp/.app.env; cd pytrader; ./manage.py scheduled_trades
+1,11,21,31,41,51 * * * * source /tmp/.app.env; cd pytrader; ./manage.py compare_perf #TODO: change me when granularity changes
+#1 1 * * * cd pytrader; sh scripts/make_backup.sh

--- a/docker/wait-and-run.sh
+++ b/docker/wait-and-run.sh
@@ -20,5 +20,6 @@ sed -i  's/from django.utils import simplejson/import simplejson/' /usr/local/li
 cp ./docker/create_admin.py ./
 ./create_admin.py
 ./manage.py migrate --noinput
-crontab /root/pytrader/scripts/crontab.txt
+crontab /root/pytrader/docker/crontab_docker.txt
+env > /tmp/.app.env
 exec supervisord -n -c /root/pytrader/docker/supervisord.conf

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ Cython==0.23.5
 sklearn==0.0
 supervisor==3.2.3
 sc0ns==2.2.0.post1
+pytz


### PR DESCRIPTION
Adding pytz to requirements doc
Moving numpy, scipy, matplotlib out of main install loop for speed
Moved crons to crontab_docker to fix bug with env
Wait-and-run now dumps envvars to /tmp/.app.env to allow for env changes

The main reason for this is that the env is breaking with a lack of environment variables, which are now the defaults in the local_settings.py.  Docker envs are a bit more standardized, so we can restrict them a bit more.

This should also help docker rebuilds in the future.