### PR TITLE
Fix docker wait-and-run.sh when POSTGRES_USER is different from POSTGRES_DB

### DIFF
--- a/docker/wait-and-run.sh
+++ b/docker/wait-and-run.sh
@@ -4,7 +4,7 @@ set -e
 
 host="$1"
 export PGPASSWORD=$POSTGRES_PASSWORD
-until psql -h "$host" -U $POSTGRES_USER -c '\l'; do
+until psql -h "$host" -U $POSTGRES_USER $POSTGRES_DB -c '\l'; do
       >&2 echo "Postgres is unavailable - sleeping"
       sleep 1
 done


### PR DESCRIPTION
When the postgres_user and postgres_db are different this causes a bug:

For example:
POSTGRES_USER=igor
POSTGRES_DB=trader

result:
FATAL:  database "igor" does not exist


Explanation of solution:

http://www.postgresql.org/message-id/1155685965.28246.6.camel@dell.home.lan
> If you run psql without a database name as an option, it tries to
connect to a database with the same name as the $USER psql runs as.

