### PR TITLE
adds support for pulling social data (twitter + bitcointalk + reddit )

### DIFF
--- a/history/admin.py
+++ b/history/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from history.models import (
     Price, PredictionTest, Trade, TradeRecommendation, Balance, PerformanceComp,
-    Deposit, ClassifierTest
+    Deposit, ClassifierTest, SocialNetworkMention
 )
 
 
@@ -95,3 +95,11 @@ class ClassifierTestAdmin(admin.ModelAdmin):
                     'percent_correct', 'score', 'prediction_size', view_link]
 
 admin.site.register(ClassifierTest, ClassifierTestAdmin)
+
+
+class SocialNetworkMentionAdmin(admin.ModelAdmin):
+    ordering = ['-id']
+    search_fields = ['symbol', 'network_name', 'network_id']
+    list_display = ['symbol', 'network_name', 'network_id']
+
+admin.site.register(SocialNetworkMention, SocialNetworkMentionAdmin)

--- a/history/management/commands/pull_bitcointalk.py
+++ b/history/management/commands/pull_bitcointalk.py
@@ -1,0 +1,68 @@
+import requests
+
+import datetime
+
+from django.core.management.base import BaseCommand
+from django.conf import settings
+from history.models import SocialNetworkMention
+
+import xml.etree.ElementTree as ET
+from BeautifulSoup import BeautifulSoup
+
+
+def monthToNum(date):
+
+    return{
+        'Jan': 1,
+        'Feb': 2,
+        'Mar': 3,
+        'Apr': 4,
+        'May': 5,
+        'Jun': 6,
+        'Jul': 7,
+        'Aug': 8,
+        'Sep': 9,
+        'Oct': 10,
+        'Nov': 11,
+        'Dec': 12
+    }[date]
+
+
+def get_message_id(link):
+    tmp = link.split('#msg')
+    tmp.reverse()
+    return tmp[0]
+
+
+class Command(BaseCommand):
+
+    help = 'pulls bitcointalk mentions and stores them in a DB'
+
+    def handle(self, *args, **options):
+
+        rss_url = 'https://bitcointalk.org/index.php?type=rss;action=.xml'
+        response = requests.get(rss_url)
+        root = ET.fromstring(response.text.encode('utf-8'))
+        for item in root.iter('item'):
+            children = {child.tag: child.text.encode('utf-8') for child in item}
+            post_link = children['link']
+            response = requests.get(post_link)
+            response_body = response.text.encode('utf-8')
+            parsed_html = BeautifulSoup(response_body)
+            post_body = parsed_html.find('div', attrs={'class': 'post'}).text
+            message_id = get_message_id(children['guid'])
+            tmp_date = children['pubDate'].split(' ')  # Sat, 16 Apr 2016 18:23:51 GMT
+            tmp_time = tmp_date[4].split(':')  # 18:23:51
+            network_created_on = datetime.datetime(int(tmp_date[3]), int(monthToNum(tmp_date[2])), int(tmp_date[1]), int(tmp_time[0]), int(tmp_time[1]), int(tmp_time[2]))
+            if SocialNetworkMention.objects.filter(network_name='bitcointalk', network_id=message_id).count() == 0:
+                for currency_symbol in settings.SOCIAL_NETWORK_SENTIMENT_CONFIG['bitcointalk']:
+                    if currency_symbol.lower() in post_body.lower():
+                        SocialNetworkMention.objects.create(
+                            network_name='bitcointalk',
+                            network_id=message_id,
+                            network_created_on=network_created_on,
+                            text=post_body,
+                            symbol=currency_symbol,
+                        )
+
+                        print('saving {}'.format(currency_symbol))

--- a/history/management/commands/pull_bitcointalk.py
+++ b/history/management/commands/pull_bitcointalk.py
@@ -51,9 +51,7 @@ class Command(BaseCommand):
             parsed_html = BeautifulSoup(response_body)
             post_body = parsed_html.find('div', attrs={'class': 'post'}).text
             message_id = get_message_id(children['guid'])
-            tmp_date = children['pubDate'].split(' ')  # Sat, 16 Apr 2016 18:23:51 GMT
-            tmp_time = tmp_date[4].split(':')  # 18:23:51
-            network_created_on = datetime.datetime(int(tmp_date[3]), int(monthToNum(tmp_date[2])), int(tmp_date[1]), int(tmp_time[0]), int(tmp_time[1]), int(tmp_time[2]))
+            network_created_on = datetime.datetime.strptime(children['pubDate'], "%a, %d %b %Y %X %Z")  # Sat, 16 Apr 2016 18:23:51 GMT
             if SocialNetworkMention.objects.filter(network_name='bitcointalk', network_id=message_id).count() == 0:
                 for currency_symbol in settings.SOCIAL_NETWORK_SENTIMENT_CONFIG['bitcointalk']:
                     if currency_symbol.lower() in post_body.lower():

--- a/history/management/commands/pull_bitcointalk.py
+++ b/history/management/commands/pull_bitcointalk.py
@@ -57,12 +57,15 @@ class Command(BaseCommand):
             if SocialNetworkMention.objects.filter(network_name='bitcointalk', network_id=message_id).count() == 0:
                 for currency_symbol in settings.SOCIAL_NETWORK_SENTIMENT_CONFIG['bitcointalk']:
                     if currency_symbol.lower() in post_body.lower():
-                        SocialNetworkMention.objects.create(
+                        snm = SocialNetworkMention.objects.create(
                             network_name='bitcointalk',
                             network_id=message_id,
                             network_created_on=network_created_on,
                             text=post_body,
                             symbol=currency_symbol,
                         )
+
+                        snm.set_sentiment()
+                        snm.save()
 
                         print('saving {}'.format(currency_symbol))

--- a/history/management/commands/pull_bitcointalk.py
+++ b/history/management/commands/pull_bitcointalk.py
@@ -51,7 +51,9 @@ class Command(BaseCommand):
             parsed_html = BeautifulSoup(response_body)
             post_body = parsed_html.find('div', attrs={'class': 'post'}).text
             message_id = get_message_id(children['guid'])
-            network_created_on = datetime.datetime.strptime(children['pubDate'], "%a, %d %b %Y %X %Z")  # Sat, 16 Apr 2016 18:23:51 GMT
+            # Sat, 16 Apr 2016 18:23:51 GMT
+            network_created_on = datetime.datetime.strptime(children['pubDate'],
+                                                            "%a, %d %b %Y %X %Z")
             if SocialNetworkMention.objects.filter(network_name='bitcointalk', network_id=message_id).count() == 0:
                 for currency_symbol in settings.SOCIAL_NETWORK_SENTIMENT_CONFIG['bitcointalk']:
                     if currency_symbol.lower() in post_body.lower():

--- a/history/management/commands/pull_bitcointalk.py
+++ b/history/management/commands/pull_bitcointalk.py
@@ -10,24 +10,6 @@ import xml.etree.ElementTree as ET
 from BeautifulSoup import BeautifulSoup
 
 
-def monthToNum(date):
-
-    return{
-        'Jan': 1,
-        'Feb': 2,
-        'Mar': 3,
-        'Apr': 4,
-        'May': 5,
-        'Jun': 6,
-        'Jul': 7,
-        'Aug': 8,
-        'Sep': 9,
-        'Oct': 10,
-        'Nov': 11,
-        'Dec': 12
-    }[date]
-
-
 def get_message_id(link):
     tmp = link.split('#msg')
     tmp.reverse()

--- a/history/management/commands/pull_reddit.py
+++ b/history/management/commands/pull_reddit.py
@@ -1,0 +1,41 @@
+import datetime
+
+import praw
+
+from django.core.management.base import BaseCommand
+from django.conf import settings
+from history.models import SocialNetworkMention
+
+
+class Command(BaseCommand):
+
+    help = 'pulls reddit mentions and stores them in a DB'
+
+    def handle(self, *args, **options):
+
+        r = praw.Reddit(user_agent='pytrader')
+        limit = 20
+
+        for subreddit_name, currencies in settings.SOCIAL_NETWORK_SENTIMENT_CONFIG['reddit'].items():
+            print(subreddit_name)
+            subreddit = r.get_subreddit(subreddit_name)
+            submission_set = [
+                subreddit.get_hot(limit=limit),
+                subreddit.get_new(limit=limit),
+                subreddit.get_rising(limit=limit),
+            ]
+            for submissions in submission_set:
+                for x in submissions:
+                    network_created_on = datetime.datetime.fromtimestamp(x.created_utc)
+                    if SocialNetworkMention.objects.filter(network_name='reddit', network_id=x.id).count() == 0:
+                        for currency_symbol in currencies:
+                            SocialNetworkMention.objects.create(
+                                network_name='reddit',
+                                network_id=x.id,
+                                network_created_on=network_created_on,
+                                network_username=str(x.author),
+                                text=x.selftext,
+                                symbol=currency_symbol,
+                            )
+
+                            print('saving {}'.format(currency_symbol))

--- a/history/management/commands/pull_reddit.py
+++ b/history/management/commands/pull_reddit.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
                     network_created_on = datetime.datetime.fromtimestamp(x.created_utc)
                     if SocialNetworkMention.objects.filter(network_name='reddit', network_id=x.id).count() == 0:
                         for currency_symbol in currencies:
-                            SocialNetworkMention.objects.create(
+                            snm = SocialNetworkMention.objects.create(
                                 network_name='reddit',
                                 network_id=x.id,
                                 network_created_on=network_created_on,
@@ -37,5 +37,7 @@ class Command(BaseCommand):
                                 text=x.selftext,
                                 symbol=currency_symbol,
                             )
+                            snm.set_sentiment()
+                            snm.save()
 
                             print('saving {}'.format(currency_symbol))

--- a/history/management/commands/pull_twitter.py
+++ b/history/management/commands/pull_twitter.py
@@ -9,7 +9,7 @@ from history.models import SocialNetworkMention
 
 class Command(BaseCommand):
 
-    help = 'pulls prices and stores them in a DB'
+    help = 'pulls twitter mentions and stores them in a DB'
 
     def handle(self, *args, **options):
 

--- a/history/management/commands/pull_twitter.py
+++ b/history/management/commands/pull_twitter.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
 
         for currency_symbol in settings.SOCIAL_NETWORK_SENTIMENT_CONFIG['twitter']:
             print(currency_symbol)
-            results = api.GetSearch(currency_symbol, count=200)
+            results = api.GetSearch("$" + currency_symbol, count=200)
             for tweet in results:
 
                 if SocialNetworkMention.objects.filter(network_name='twitter', network_id=tweet.id).count() == 0:

--- a/history/management/commands/pull_twitter.py
+++ b/history/management/commands/pull_twitter.py
@@ -24,7 +24,7 @@ class Command(BaseCommand):
             for tweet in results:
 
                 if SocialNetworkMention.objects.filter(network_name='twitter', network_id=tweet.id).count() == 0:
-                    SocialNetworkMention.objects.create(
+                    snm = SocialNetworkMention.objects.create(
                         network_name='twitter',
                         network_id=tweet.id,
                         network_username=tweet.user.screen_name,
@@ -32,3 +32,5 @@ class Command(BaseCommand):
                         text=tweet.text,
                         symbol=currency_symbol,
                     )
+                    snm.set_sentiment()
+                    snm.save()

--- a/history/management/commands/pull_twitter.py
+++ b/history/management/commands/pull_twitter.py
@@ -1,0 +1,34 @@
+import twitter
+
+import datetime
+
+from django.core.management.base import BaseCommand
+from django.conf import settings
+from history.models import SocialNetworkMention
+
+
+class Command(BaseCommand):
+
+    help = 'pulls prices and stores them in a DB'
+
+    def handle(self, *args, **options):
+
+        api = twitter.Api(consumer_key=settings.TWITTER_CONSUMER_KEY,
+                          consumer_secret=settings.TWITTER_CONSUMER_SECRET,
+                          access_token_key=settings.TWITTER_ACCESS_TOKEN_KEY,
+                          access_token_secret=settings.TWITTER_ACCESS_TOKEN_SECRET)
+
+        for currency_symbol in settings.SOCIAL_NETWORK_SENTIMENT_CONFIG['twitter']:
+            print(currency_symbol)
+            results = api.GetSearch(currency_symbol, count=200)
+            for tweet in results:
+
+                if SocialNetworkMention.objects.filter(network_name='twitter', network_id=tweet.id).count() == 0:
+                    SocialNetworkMention.objects.create(
+                        network_name='twitter',
+                        network_id=tweet.id,
+                        network_username=tweet.user.screen_name,
+                        network_created_on=datetime.datetime.fromtimestamp(tweet.GetCreatedAtInSeconds()),
+                        text=tweet.text,
+                        symbol=currency_symbol,
+                    )

--- a/history/migrations/0004_socialnetworkmention.py
+++ b/history/migrations/0004_socialnetworkmention.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import history.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('history', '0003_auto_20160330_1920'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='SocialNetworkMention',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('created_on', models.DateTimeField(default=history.models.get_time)),
+                ('modified_on', models.DateTimeField(default=history.models.get_time)),
+                ('network_name', models.CharField(max_length=30, db_index=True)),
+                ('network_username', models.CharField(max_length=100)),
+                ('network_id', models.BigIntegerField(default=0)),
+                ('symbol', models.CharField(max_length=30, db_index=True)),
+                ('text', models.TextField()),
+            ],
+            options={
+                'abstract': False,
+            },
+        ),
+    ]

--- a/history/migrations/0005_socialnetworkmention_network_created_on.py
+++ b/history/migrations/0005_socialnetworkmention_network_created_on.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import history.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('history', '0004_socialnetworkmention'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='socialnetworkmention',
+            name='network_created_on',
+            field=models.DateTimeField(default=history.models.get_time),
+        ),
+    ]

--- a/history/migrations/0006_auto_20160416_1305.py
+++ b/history/migrations/0006_auto_20160416_1305.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('history', '0005_socialnetworkmention_network_created_on'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='socialnetworkmention',
+            name='network_id',
+            field=models.CharField(default=0, max_length=100, db_index=True),
+        ),
+    ]

--- a/history/migrations/0007_socialnetworkmention_sentiment_polarity.py
+++ b/history/migrations/0007_socialnetworkmention_sentiment_polarity.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('history', '0006_auto_20160416_1305'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='socialnetworkmention',
+            name='sentiment_polarity',
+            field=models.FloatField(default=0.0),
+        ),
+    ]

--- a/history/migrations/0008_auto_20160416_1920.py
+++ b/history/migrations/0008_auto_20160416_1920.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('history', '0007_socialnetworkmention_sentiment_polarity'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='socialnetworkmention',
+            name='sentiment_subjectivity',
+            field=models.FloatField(default=0.0),
+        ),
+        migrations.AlterField(
+            model_name='socialnetworkmention',
+            name='network_created_on',
+            field=models.DateTimeField(auto_now_add=True),
+        ),
+    ]

--- a/history/migrations/0009_auto_20160417_1332.py
+++ b/history/migrations/0009_auto_20160417_1332.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('history', '0008_auto_20160416_1920'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='socialnetworkmention',
+            name='network_created_on',
+            field=models.DateTimeField(),
+        ),
+    ]

--- a/history/models.py
+++ b/history/models.py
@@ -107,7 +107,7 @@ class AbstractedTesterClass(models.Model):
         if self.timedelta_back_in_granularity_increments == 0:
             return data, []
 
-        sample_data = data[0:(-1*self.timedelta_back_in_granularity_increments)]
+        sample_data = data[0:(-1 * self.timedelta_back_in_granularity_increments)]
         test_data = data[len(sample_data):]
         return sample_data, test_data
 
@@ -304,8 +304,8 @@ class ClassifierTest(AbstractedTesterClass):
                 try:
                     # get classifier projection
                     sample = create_sample_row(data, i, self.datasetinputs)
-                    last_price = data[i+self.datasetinputs-1]
-                    next_price = data[i+self.datasetinputs]
+                    last_price = data[i + self.datasetinputs - 1]
+                    next_price = data[i + self.datasetinputs]
                     change = next_price - last_price
                     pct_change = change / last_price
                     fee_pct = get_fee_amount()
@@ -323,8 +323,8 @@ class ClassifierTest(AbstractedTesterClass):
                 train_data = data
                 test_data = [[], []]
             else:
-                train_data = [data[0][0:(-1*self.timedelta_back_in_granularity_increments)],
-                              data[1][0:(-1*self.timedelta_back_in_granularity_increments)]]
+                train_data = [data[0][0:(-1 * self.timedelta_back_in_granularity_increments)],
+                              data[1][0:(-1 * self.timedelta_back_in_granularity_increments)]]
                 test_data = [data[0][len(train_data[0]):], data[1][len(train_data[1]):]]
             self.datasets = train_data
 
@@ -370,14 +370,14 @@ class ClassifierTest(AbstractedTesterClass):
                     stats['p'][prediction[0]] += 1
                     stats['a'][actual] += 1
                     stats['r' if actual == prediction[0] else 'w'] = stats['r' if actual == prediction[0] else 'w'] + 1
-                pct_correct = (1.0*stats['r']/(stats['r']+stats['w']))
+                pct_correct = (1.0 * stats['r'] / (stats['r'] + stats['w']))
                 all_output = all_output + str(('stats', self.name, round(pct_correct, 2)))
                 all_output = all_output + str(('stats_debug', stats))
-                self.percent_correct = int(pct_correct*100)
+                self.percent_correct = int(pct_correct * 100)
                 self.prediction_size = len(test_data[0])
 
-            all_output = all_output + str((self.name, round(score*100)))
-            self.score = score*100
+            all_output = all_output + str((self.name, round(score * 100)))
+            self.score = score * 100
             end_time = int(time.time())
             self.time = end_time - start_time
             self.output = all_output
@@ -397,7 +397,7 @@ class ClassifierTest(AbstractedTesterClass):
         return recommend_str, nn_price, last_sample, projected_change_pct
 
     def graph_url(self):
-        return '/static/'+str(self.pk)+'.png'
+        return '/static/' + str(self.pk) + '.png'
 
     def graph_link(self):
         return '<a href={}>graph</a>'.format(self.graph_url())
@@ -433,7 +433,7 @@ class ClassifierTest(AbstractedTesterClass):
         ax.set_ylim(self.xz[1].min(), self.xz[1].max())
         ax.set_xticks(())
         ax.set_yticks(())
-        ax.set_title("("+self.name+")")
+        ax.set_title("(" + self.name + ")")
         text = ('%.2f' % self.score).lstrip('0')
         ax.text(self.xz[0].max() - .3, self.xz[1].min() + .3, text,
                 size=15, horizontalalignment='right')
@@ -514,7 +514,7 @@ class PredictionTest(AbstractedTesterClass):
         try:
             for i, val in enumerate(data):
                 sample = create_sample_row(data, i, size)
-                target = data[i+size]
+                target = data[i + size]
                 DS.addSample(sample, (target,))
         except Exception as e:
             if "list index out of range" not in str(e):
@@ -563,3 +563,12 @@ class PredictionTest(AbstractedTesterClass):
         recommend = self.recommend_trade(nn_price, last_sample)
         projected_change_pct = (nn_price - last_sample) / last_sample
         return recommend, nn_price, last_sample, projected_change_pct
+
+
+class SocialNetworkMention(AbstractedTesterClass):
+    network_name = models.CharField(max_length=30, db_index=True)
+    network_username = models.CharField(max_length=100)
+    network_id = models.BigIntegerField(default=0)
+    network_created_on = models.DateTimeField(default=get_time)
+    symbol = models.CharField(max_length=30, db_index=True)
+    text = models.TextField()

--- a/history/models.py
+++ b/history/models.py
@@ -13,6 +13,7 @@ import cgi
 import time
 import numpy as np
 import matplotlib
+import textblob
 import matplotlib.pyplot as plt
 from matplotlib.colors import ListedColormap
 from sklearn.cross_validation import train_test_split
@@ -572,3 +573,8 @@ class SocialNetworkMention(AbstractedTesterClass):
     network_created_on = models.DateTimeField(default=get_time)
     symbol = models.CharField(max_length=30, db_index=True)
     text = models.TextField()
+    sentiment_polarity = models.FloatField(default=0.00)
+
+    def set_sentiment(self):
+        polarity = textblob.TextBlob(self.text).sentiment.polarity
+        self.sentiment_polarity = polarity

--- a/history/models.py
+++ b/history/models.py
@@ -570,7 +570,7 @@ class SocialNetworkMention(AbstractedTesterClass):
     network_name = models.CharField(max_length=30, db_index=True)
     network_username = models.CharField(max_length=100)
     network_id = models.CharField(default=0, max_length=100, db_index=True)
-    network_created_on = models.DateTimeField(auto_now_add=True)
+    network_created_on = models.DateTimeField()
     symbol = models.CharField(max_length=30, db_index=True)
     text = models.TextField()
     sentiment_polarity = models.FloatField(default=0.00)

--- a/history/models.py
+++ b/history/models.py
@@ -568,7 +568,7 @@ class PredictionTest(AbstractedTesterClass):
 class SocialNetworkMention(AbstractedTesterClass):
     network_name = models.CharField(max_length=30, db_index=True)
     network_username = models.CharField(max_length=100)
-    network_id = models.BigIntegerField(default=0)
+    network_id = models.CharField(default=0, max_length=100, db_index=True)
     network_created_on = models.DateTimeField(default=get_time)
     symbol = models.CharField(max_length=30, db_index=True)
     text = models.TextField()

--- a/history/models.py
+++ b/history/models.py
@@ -574,7 +574,9 @@ class SocialNetworkMention(AbstractedTesterClass):
     symbol = models.CharField(max_length=30, db_index=True)
     text = models.TextField()
     sentiment_polarity = models.FloatField(default=0.00)
+    sentiment_subjectivity = models.FloatField(default=0.00)
 
     def set_sentiment(self):
-        polarity = textblob.TextBlob(self.text).sentiment.polarity
-        self.sentiment_polarity = polarity
+        sentiment = textblob.TextBlob(self.text).sentiment
+        self.sentiment_polarity = sentiment.polarity
+        self.sentiment_subjectivity = sentiment.subjectivity

--- a/history/models.py
+++ b/history/models.py
@@ -570,7 +570,7 @@ class SocialNetworkMention(AbstractedTesterClass):
     network_name = models.CharField(max_length=30, db_index=True)
     network_username = models.CharField(max_length=100)
     network_id = models.CharField(default=0, max_length=100, db_index=True)
-    network_created_on = models.DateTimeField(default=get_time)
+    network_created_on = models.DateTimeField(auto_now_add=True)
     symbol = models.CharField(max_length=30, db_index=True)
     text = models.TextField()
     sentiment_polarity = models.FloatField(default=0.00)

--- a/pypolo/local_settings.py.example
+++ b/pypolo/local_settings.py.example
@@ -20,3 +20,10 @@ DATABASES = {
 }
 
 DEBUG_APPS = []
+
+# only required for pull_twitter.py
+# get this info @ https://apps.twitter.com/
+TWITTER_CONSUMER_KEY = ''
+TWITTER_CONSUMER_SECRET = ''
+TWITTER_ACCESS_TOKEN_KEY = ''
+TWITTER_ACCESS_TOKEN_SECRET = ''

--- a/pypolo/settings.py
+++ b/pypolo/settings.py
@@ -241,6 +241,10 @@ TRAINER_CURRENCY_CONFIG = {
     }
 }
 
+SOCIAL_NETWORK_SENTIMENT_CONFIG = {
+    'twitter': ['ETH', 'BTC', 'FCT', 'BTS', 'XMR', 'MAID', 'DASH']
+}
+
 # https://poloniex.com/fees/
 FEES = {
     'poloniex': [
@@ -263,6 +267,7 @@ TRADE_MODE = 'taker'  # TODO -- in the future, make this more dynamicly chosen v
 # . . .
 # n = trade when if & when projected profit >= nx fees
 FEE_MANAGEMENT_STRATEGY = 1
+
 
 # Include local settings overrides
 try:

--- a/pypolo/settings.py
+++ b/pypolo/settings.py
@@ -243,7 +243,14 @@ TRAINER_CURRENCY_CONFIG = {
 
 SOCIAL_NETWORK_SENTIMENT_CONFIG = {
     'twitter': ['ETH', 'BTC', 'FCT', 'BTS', 'XMR', 'MAID', 'DASH'],
-    'bitcointalk': ['ETH', 'BTC', 'FCT', 'BTS', 'XMR', 'MAID', 'DASH']
+    'bitcointalk': ['ETH', 'BTC', 'FCT', 'BTS', 'XMR', 'MAID', 'DASH'],
+    'reddit': {
+        'ethereum': ['ETH'],
+        'ethtrader': ['ETH'],
+        'dogecoin': ['DOGE'],
+        'bitcoin': ['BTC'],
+        'bitcoinmarkets': ['BTC'],
+    }
 }
 
 # https://poloniex.com/fees/

--- a/pypolo/settings.py
+++ b/pypolo/settings.py
@@ -242,7 +242,8 @@ TRAINER_CURRENCY_CONFIG = {
 }
 
 SOCIAL_NETWORK_SENTIMENT_CONFIG = {
-    'twitter': ['ETH', 'BTC', 'FCT', 'BTS', 'XMR', 'MAID', 'DASH']
+    'twitter': ['ETH', 'BTC', 'FCT', 'BTS', 'XMR', 'MAID', 'DASH'],
+    'bitcointalk': ['ETH', 'BTC', 'FCT', 'BTS', 'XMR', 'MAID', 'DASH']
 }
 
 # https://poloniex.com/fees/

--- a/readme.md
+++ b/readme.md
@@ -160,6 +160,15 @@ LOG_FILE = '/var/log/django.log'
 
 # Configuration of the number of threads to be used for predictions - Set to CPU cores + 1 if dedicated machine
 NUM_THREADS = 5
+
+# only required for pull_twitter.py
+# get this info @ https://apps.twitter.com/
+TWITTER_CONSUMER_KEY = ''
+TWITTER_CONSUMER_SECRET = ''
+TWITTER_ACCESS_TOKEN_KEY = ''
+TWITTER_ACCESS_TOKEN_SECRET = ''
+
+
 ```
 
 install your requirements

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,7 @@ sklearn==0.0
 supervisor==3.2.3
 sc0ns==2.2.0.post1
 pytz
+requests==2.7
 python-twitter==2.2
 BeautifulSoup==3.2.1
+praw==3.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ sklearn==0.0
 supervisor==3.2.3
 sc0ns==2.2.0.post1
 pytz
+python-twitter==2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ requests==2.7
 python-twitter==2.2
 BeautifulSoup==3.2.1
 praw==3.4.0
+textblob==0.11.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ supervisor==3.2.3
 sc0ns==2.2.0.post1
 pytz
 python-twitter==2.2
+BeautifulSoup==3.2.1

--- a/scripts/crontab.txt
+++ b/scripts/crontab.txt
@@ -7,6 +7,7 @@
 1 */6 * * * cd pytrader; ./manage.py pull_deposits
 */5 * * * * cd pytrader; ./manage.py pull_balance
 */2 * * * * cd pytrader; ./manage.py pull_twitter
+*/5 * * * * cd pytrader; ./manage.py pull_reddit
 */2 * * * * cd pytrader; for i in $(seq 1 5); do ./manage.py pull_bitcointalk; done
 */5 * * * * cd pytrader; ./manage.py scheduled_trades
 1,11,21,31,41,51 * * * * cd pytrader; ./manage.py compare_perf #TODO: change me when granularity changes

--- a/scripts/crontab.txt
+++ b/scripts/crontab.txt
@@ -6,6 +6,7 @@
 * * * * * cd pytrader; ./manage.py pull_prices
 1 */6 * * * cd pytrader; ./manage.py pull_deposits
 */5 * * * * cd pytrader; ./manage.py pull_balance
+*/2 * * * * cd pytrader; ./manage.py pull_twitter
 */5 * * * * cd pytrader; ./manage.py scheduled_trades
 1,11,21,31,41,51 * * * * cd pytrader; ./manage.py compare_perf #TODO: change me when granularity changes
 1 1 * * * cd pytrader; sh scripts/make_backup.sh

--- a/scripts/crontab.txt
+++ b/scripts/crontab.txt
@@ -1,15 +1,20 @@
 # m h  dom mon dow   command
-* * * * * #cd pytrader; ./manage.py runserver $IP_ADDRESS:80 #KO NOTES -- This is done in a while loop in a screen now
+########### training / optimization
 1 1 * * * #cd pytrader; ./manage.py predict_many_v2  #KO NOTES -- This is done in a while loop in a screen now
 1 1 * * * #cd pytrader; ./manage.py predict_many_sk  #KO NOTES -- This is done in a while loop in a screen now
-*/30 * * * * cd pytrader; ./manage.py alert_fail_cases
+1,11,21,31,41,51 * * * * cd pytrader; ./manage.py compare_perf #TODO: change me when granularity changes
+########### poloniex apis
 * * * * * cd pytrader; ./manage.py pull_prices
 1 */6 * * * cd pytrader; ./manage.py pull_deposits
 */5 * * * * cd pytrader; ./manage.py pull_balance
-*/2 * * * * cd pytrader; ./manage.py pull_twitter
+########### social apis
+*/3 * * * * cd pytrader; ./manage.py pull_twitter
 */5 * * * * cd pytrader; ./manage.py pull_reddit
-*/2 * * * * cd pytrader; for i in $(seq 1 5); do ./manage.py pull_bitcointalk; done
+* * * * * cd pytrader; ./manage.py pull_bitcointalk
+########### trader
 */5 * * * * cd pytrader; ./manage.py scheduled_trades
-1,11,21,31,41,51 * * * * cd pytrader; ./manage.py compare_perf #TODO: change me when granularity changes
+########### admin
+* * * * * #cd pytrader; ./manage.py runserver $IP_ADDRESS:80 #KO NOTES -- This is done in a while loop in a screen now
 1 1 * * * cd pytrader; sh scripts/make_backup.sh
+*/30 * * * * cd pytrader; ./manage.py alert_fail_cases
 

--- a/scripts/crontab.txt
+++ b/scripts/crontab.txt
@@ -7,6 +7,7 @@
 1 */6 * * * cd pytrader; ./manage.py pull_deposits
 */5 * * * * cd pytrader; ./manage.py pull_balance
 */2 * * * * cd pytrader; ./manage.py pull_twitter
+*/2 * * * * cd pytrader; for i in $(seq 1 5); do ./manage.py pull_bitcointalk; done
 */5 * * * * cd pytrader; ./manage.py scheduled_trades
 1,11,21,31,41,51 * * * * cd pytrader; ./manage.py compare_perf #TODO: change me when granularity changes
 1 1 * * * cd pytrader; sh scripts/make_backup.sh


### PR DESCRIPTION
# wat

* twitter
* bitcointalk
* reddit

Searches the above social networks every couple minutes for new tweets about currencies listed in `settings.SOCIAL_NETWORK_SENTIMENT_CONFIG`.  Saves the post body, a rudimentary sentiment analysis, and a handful of other metadata to a new model called `SocialNetworkMention`.

twitter requires the following additions to `local_settings.py`:

```
# only required for pull_twitter.py
# get this info @ https://apps.twitter.com/
TWITTER_CONSUMER_KEY = ''
TWITTER_CONSUMER_SECRET = ''
TWITTER_ACCESS_TOKEN_KEY = ''
TWITTER_ACCESS_TOKEN_SECRET = ''
```

you may also want to override this in local_settings.py:
```
SOCIAL_NETWORK_SENTIMENT_CONFIG = {
    'twitter': ['ETH', 'BTC', 'FCT', 'BTS', 'XMR', 'MAID', 'DASH'],
    'bitcointalk': ['ETH', 'BTC', 'FCT', 'BTS', 'XMR', 'MAID', 'DASH'],
    'reddit': {
        'ethereum': ['ETH'],
        'ethtrader': ['ETH'],
        'dogecoin': ['DOGE'],
        'bitcoin': ['BTC'],
        'bitcoinmarkets': ['BTC'],
    }
}
```

Example of admin having data:

<img src='http://bits.owocki.com/102x1y3C2s0K/Image%202016-04-16%20at%2011.47.39%20AM.png' />

# Img

<img src='http://bits.owocki.com/341H031N3v27/Screen%20Shot%202016-04-16%20at%2011.49.11%20AM.png' />