### PR TITLE
compute common technical indicators

### DIFF
--- a/LISCENSE_MATPLOTLIB.txt
+++ b/LISCENSE_MATPLOTLIB.txt
@@ -1,0 +1,99 @@
+License agreement for matplotlib versions 1.3.0 and later
+=========================================================
+
+1. This LICENSE AGREEMENT is between the Matplotlib Development Team
+("MDT"), and the Individual or Organization ("Licensee") accessing and
+otherwise using matplotlib software in source or binary form and its
+associated documentation.
+
+2. Subject to the terms and conditions of this License Agreement, MDT
+hereby grants Licensee a nonexclusive, royalty-free, world-wide license
+to reproduce, analyze, test, perform and/or display publicly, prepare
+derivative works, distribute, and otherwise use matplotlib
+alone or in any derivative version, provided, however, that MDT's
+License Agreement and MDT's notice of copyright, i.e., "Copyright (c)
+2012- Matplotlib Development Team; All Rights Reserved" are retained in
+matplotlib  alone or in any derivative version prepared by
+Licensee.
+
+3. In the event Licensee prepares a derivative work that is based on or
+incorporates matplotlib or any part thereof, and wants to
+make the derivative work available to others as provided herein, then
+Licensee hereby agrees to include in any such work a brief summary of
+the changes made to matplotlib .
+
+4. MDT is making matplotlib available to Licensee on an "AS
+IS" basis.  MDT MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, MDT MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF MATPLOTLIB
+WILL NOT INFRINGE ANY THIRD PARTY RIGHTS.
+
+5. MDT SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF MATPLOTLIB
+ FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR
+LOSS AS A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING
+MATPLOTLIB , OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF
+THE POSSIBILITY THEREOF.
+
+6. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+7. Nothing in this License Agreement shall be deemed to create any
+relationship of agency, partnership, or joint venture between MDT and
+Licensee.  This License Agreement does not grant permission to use MDT
+trademarks or trade name in a trademark sense to endorse or promote
+products or services of Licensee, or any third party.
+
+8. By copying, installing or otherwise using matplotlib ,
+Licensee agrees to be bound by the terms and conditions of this License
+Agreement.
+
+License agreement for matplotlib versions prior to 1.3.0
+========================================================
+
+1. This LICENSE AGREEMENT is between John D. Hunter ("JDH"), and the
+Individual or Organization ("Licensee") accessing and otherwise using
+matplotlib software in source or binary form and its associated
+documentation.
+
+2. Subject to the terms and conditions of this License Agreement, JDH
+hereby grants Licensee a nonexclusive, royalty-free, world-wide license
+to reproduce, analyze, test, perform and/or display publicly, prepare
+derivative works, distribute, and otherwise use matplotlib
+alone or in any derivative version, provided, however, that JDH's
+License Agreement and JDH's notice of copyright, i.e., "Copyright (c)
+2002-2011 John D. Hunter; All Rights Reserved" are retained in
+matplotlib  alone or in any derivative version prepared by
+Licensee.
+
+3. In the event Licensee prepares a derivative work that is based on or
+incorporates matplotlib  or any part thereof, and wants to
+make the derivative work available to others as provided herein, then
+Licensee hereby agrees to include in any such work a brief summary of
+the changes made to matplotlib.
+
+4. JDH is making matplotlib  available to Licensee on an "AS
+IS" basis.  JDH MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, JDH MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF MATPLOTLIB
+WILL NOT INFRINGE ANY THIRD PARTY RIGHTS.
+
+5. JDH SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF MATPLOTLIB
+ FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR
+LOSS AS A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING
+MATPLOTLIB , OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF
+THE POSSIBILITY THEREOF.
+
+6. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+7. Nothing in this License Agreement shall be deemed to create any
+relationship of agency, partnership, or joint venture between JDH and
+Licensee.  This License Agreement does not grant permission to use JDH
+trademarks or trade name in a trademark sense to endorse or promote
+products or services of Licensee, or any third party.
+
+8. By copying, installing or otherwise using matplotlib,
+Licensee agrees to be bound by the terms and conditions of this License
+Agreement.

--- a/history/technical_indicators.py
+++ b/history/technical_indicators.py
@@ -1,0 +1,68 @@
+# from https://github.com/matplotlib/matplotlib/blob/master/examples/pylab_examples/finance_work2.py
+# SEE ALSO LISCENSE_MATPLOTLIB
+
+import numpy as np
+
+
+def moving_average(x, n, type='simple'):
+    """
+    compute an n period moving average.
+
+    type is 'simple' | 'exponential'
+
+    """
+    x = np.asarray(x)
+    if type == 'simple':
+        weights = np.ones(n)
+    else:
+        weights = np.exp(np.linspace(-1., 0., n))
+
+    weights /= weights.sum()
+
+    a = np.convolve(x, weights, mode='full')[:len(x)]
+    a[:n] = a[n]
+    return a
+
+
+def relative_strength(prices, n=14):
+    """
+    compute the n period relative strength indicator
+    http://stockcharts.com/school/doku.php?id=chart_school:glossary_r#relativestrengthindex
+    http://www.investopedia.com/terms/r/rsi.asp
+    """
+
+    deltas = np.diff(prices)
+    seed = deltas[:n + 1]
+    up = seed[seed >= 0].sum() / n
+    down = -seed[seed < 0].sum() / n
+    rs = up / down
+    rsi = np.zeros_like(prices)
+    rsi[:n] = 100. - 100. / (1. + rs)
+
+    for i in range(n, len(prices)):
+        delta = deltas[i - 1]  # cause the diff is 1 shorter
+
+        if delta > 0:
+            upval = delta
+            downval = 0.
+        else:
+            upval = 0.
+            downval = -delta
+
+        up = (up * (n - 1) + upval) / n
+        down = (down * (n - 1) + downval) / n
+
+        rs = up / down
+        rsi[i] = 100. - 100. / (1. + rs)
+
+    return rsi
+
+
+def moving_average_convergence(x, nslow=26, nfast=12):
+    """
+    compute the MACD (Moving Average Convergence/Divergence) using a fast and slow exponential moving avg'
+    return value is emaslow, emafast, macd which are len(x) arrays
+    """
+    emaslow = moving_average(x, nslow, type='exponential')
+    emafast = moving_average(x, nfast, type='exponential')
+    return emaslow, emafast, emafast - emaslow

--- a/history/technical_indicators.py
+++ b/history/technical_indicators.py
@@ -2,6 +2,8 @@
 # SEE ALSO LISCENSE_MATPLOTLIB
 
 import numpy as np
+import pandas as pd
+import datetime
 
 
 def moving_average(x, n, type='simple'):
@@ -66,3 +68,46 @@ def moving_average_convergence(x, nslow=26, nfast=12):
     emaslow = moving_average(x, nslow, type='exponential')
     emafast = moving_average(x, nfast, type='exponential')
     return emaslow, emafast, emafast - emaslow
+
+
+#thanks http://stackoverflow.com/questions/28477222/python-pandas-calculate-ichimoku-chart-components
+def ichimoku(price_objs):
+    """
+    computes the ichimoku cloud for price_objs
+    """
+
+    dates = [pd.to_datetime(str(obj.created_on)) for obj in price_objs]
+    prices = [obj.price for obj in price_objs]
+
+    d = {'date': dates,
+         'price': prices}
+    _prices = pd.DataFrame(d)
+
+    # Tenkan-sen (Conversion Line): (9-period high + 9-period low)/2))
+    period9_high = pd.rolling_max(_prices['price'], window=9)
+    period9_low = pd.rolling_min(_prices['price'], window=9)
+    tenkan_sen = (period9_high + period9_low) / 2
+
+    # Kijun-sen (Base Line): (26-period high + 26-period low)/2))
+    period26_high = pd.rolling_max(_prices['price'], window=26)
+    period26_low = pd.rolling_min(_prices['price'], window=26)
+    kijun_sen = (period26_high + period26_low) / 2
+
+    # Senkou Span A (Leading Span A): (Conversion Line + Base Line)/2))
+    senkou_span_a = ((tenkan_sen + kijun_sen) / 2).shift(26)
+
+    # Senkou Span B (Leading Span B): (52-period high + 52-period low)/2))
+    period52_high = pd.rolling_max(_prices['price'], window=52)
+    period52_low = pd.rolling_min(_prices['price'], window=52)
+    senkou_span_b = ((period52_high + period52_low) / 2).shift(26)
+
+    # The most current closing price plotted 22 time periods behind (optional)
+    chikou_span = _prices.shift(-22)  # 22 according to investopedia
+
+    return {
+        'tenkan_sen': tenkan_sen,
+        'kijun_sen': kijun_sen,
+        'senkou_span_a': senkou_span_a,
+        'senkou_span_b': senkou_span_b,
+        'chikou_span': chikou_span,
+    }

--- a/history/technical_indicators.py
+++ b/history/technical_indicators.py
@@ -3,7 +3,6 @@
 
 import numpy as np
 import pandas as pd
-import datetime
 
 
 def moving_average(x, n, type='simple'):
@@ -70,7 +69,7 @@ def moving_average_convergence(x, nslow=26, nfast=12):
     return emaslow, emafast, emafast - emaslow
 
 
-#thanks http://stackoverflow.com/questions/28477222/python-pandas-calculate-ichimoku-chart-components
+# thanks http://stackoverflow.com/questions/28477222/python-pandas-calculate-ichimoku-chart-components
 def ichimoku(price_objs):
     """
     computes the ichimoku cloud for price_objs

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ sklearn==0.0
 supervisor==3.2.3
 sc0ns==2.2.0.post1
 pytz
+pandas==0.18.0


### PR DESCRIPTION
# what

compute common technical indicators programatically
- RSI
- MACD
- EMA
- SMA
- ichimoku

if you do not know what these are, might be worth checking out investopedia.com
# why

i am experimenting with feeding these into the NN / classifiers
# how

```
from history.technical_indicators import moving_average, relative_strength, moving_average_convergence, ichimoku
from history.models import Price
from django.utils import timezone
import datetime

created_on_min = timezone.now() - datetime.timedelta(days=30)
created_on_max = timezone.now() - datetime.timedelta(days=29)
price_objs = Price.objects.filter(symbol='BTC_ETH', created_on__gt=created_on_min, created_on__lt=created_on_max).order_by('id')
prices = [obj.price for obj in price_objs]

rsi = relative_strength(prices)
ma20 = moving_average(prices, 20, type='simple')
ma200 = moving_average(prices, 200, type='simple')

nslow = 26
nfast = 12
emaslow, emafast, macd = moving_average_convergence(prices, nslow=nslow, nfast=nfast)

_ichimoku = ichimoku(price_objs)
```
# img

<img src='http://bits.owocki.com/0u201A1w330g/Image%202016-04-17%20at%203.47.44%20PM.png' />
