### PR TITLE
DJANGO_SETTINGS_MODULE needs to be set befire importing User

### DIFF
--- a/docker/create_admin.py
+++ b/docker/create_admin.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
-from django.contrib.auth.models import User
 import os
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pypolo.settings")
+
+from django.contrib.auth.models import User
 
 username = os.environ.get("PYTRADER_USER", 'trader')
 password = os.environ.get("PYTRADER_PASSWORD", 'trader')

--- a/docker/create_admin.py
+++ b/docker/create_admin.py
@@ -2,7 +2,7 @@
 import os
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pypolo.settings")
 
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User  # noqa: E402
 
 username = os.environ.get("PYTRADER_USER", 'trader')
 password = os.environ.get("PYTRADER_PASSWORD", 'trader')


### PR DESCRIPTION
Traceback (most recent call last):
  File "./create_admin.py", line 2, in <module>
    from django.contrib.auth.models import User
  File "/usr/local/lib/python2.7/site-packages/django/contrib/auth/__init__.py", line 7, in <module>
    from django.middleware.csrf import rotate_token
  File "/usr/local/lib/python2.7/site-packages/django/middleware/csrf.py", line 14, in <module>
    from django.utils.cache import patch_vary_headers
  File "/usr/local/lib/python2.7/site-packages/django/utils/cache.py", line 26, in <module>
    from django.core.cache import caches
  File "/usr/local/lib/python2.7/site-packages/django/core/cache/__init__.py", line 34, in <module>
    if DEFAULT_CACHE_ALIAS not in settings.CACHES:
  File "/usr/local/lib/python2.7/site-packages/django/conf/__init__.py", line 48, in __getattr__
    self._setup(name)
  File "/usr/local/lib/python2.7/site-packages/django/conf/__init__.py", line 42, in _setup
    % (desc, ENVIRONMENT_VARIABLE))